### PR TITLE
Export of V8 changes from https://chromium.googlesource.com/v8/v8.git

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,6 +99,7 @@ David Sanders <dsanders11@ucsbalum.com>
 Deepak Mohan <hop2deep@gmail.com>
 Deon Dior <diaoyuanjie@gmail.com>
 Derek Tu <derek.t@rioslab.org>
+Divy Srivastava <dj.srivastava23@gmail.com>
 Dominic Chen <d.c.ddcc@gmail.com>
 Dominic Farolini <domfarolino@gmail.com>
 Douglas Crosher <dtc-v8@scieneer.com>

--- a/include/cppgc/cross-thread-persistent.h
+++ b/include/cppgc/cross-thread-persistent.h
@@ -120,7 +120,7 @@ class BasicCrossThreadPersistent final : public CrossThreadPersistentBase,
     if (!IsValid(raw)) return;
     PersistentRegionLock guard;
     CrossThreadPersistentRegion& region = this->GetPersistentRegion(raw);
-    SetNode(region.AllocateNode(this, &Trace));
+    SetNode(region.AllocateNode(this, &TraceAsRoot));
     this->CheckPointer(raw);
   }
 
@@ -138,7 +138,7 @@ class BasicCrossThreadPersistent final : public CrossThreadPersistentBase,
       : CrossThreadPersistentBase(raw), LocationPolicy(loc) {
     if (!IsValid(raw)) return;
     CrossThreadPersistentRegion& region = this->GetPersistentRegion(raw);
-    SetNode(region.AllocateNode(this, &Trace));
+    SetNode(region.AllocateNode(this, &TraceAsRoot));
     this->CheckPointer(raw);
   }
 
@@ -349,9 +349,8 @@ class BasicCrossThreadPersistent final : public CrossThreadPersistentBase,
     return ptr && ptr != kSentinelPointer;
   }
 
-  static void Trace(Visitor* v, const void* ptr) {
-    const auto* handle = static_cast<const BasicCrossThreadPersistent*>(ptr);
-    v->TraceRoot(*handle, handle->Location());
+  static void TraceAsRoot(RootVisitor& root_visitor, const void* ptr) {
+    root_visitor.Trace(*static_cast<const BasicCrossThreadPersistent*>(ptr));
   }
 
   void AssignUnsafe(T* ptr) {
@@ -378,7 +377,7 @@ class BasicCrossThreadPersistent final : public CrossThreadPersistentBase,
     SetValue(ptr);
     if (!IsValid(ptr)) return;
     PersistentRegionLock guard;
-    SetNode(this->GetPersistentRegion(ptr).AllocateNode(this, &Trace));
+    SetNode(this->GetPersistentRegion(ptr).AllocateNode(this, &TraceAsRoot));
     this->CheckPointer(ptr);
   }
 
@@ -398,7 +397,7 @@ class BasicCrossThreadPersistent final : public CrossThreadPersistentBase,
     }
     SetValue(ptr);
     if (!IsValid(ptr)) return;
-    SetNode(this->GetPersistentRegion(ptr).AllocateNode(this, &Trace));
+    SetNode(this->GetPersistentRegion(ptr).AllocateNode(this, &TraceAsRoot));
     this->CheckPointer(ptr);
   }
 
@@ -416,7 +415,7 @@ class BasicCrossThreadPersistent final : public CrossThreadPersistentBase,
     return static_cast<T*>(const_cast<void*>(GetValueFromGC()));
   }
 
-  friend class cppgc::Visitor;
+  friend class internal::RootVisitor;
 };
 
 template <typename T, typename LocationPolicy, typename CheckingPolicy>

--- a/include/cppgc/internal/member-storage.h
+++ b/include/cppgc/internal/member-storage.h
@@ -1,0 +1,220 @@
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef INCLUDE_CPPGC_INTERNAL_MEMBER_STORAGE_H_
+#define INCLUDE_CPPGC_INTERNAL_MEMBER_STORAGE_H_
+
+#include <atomic>
+#include <cstddef>
+#include <type_traits>
+
+#include "cppgc/internal/api-constants.h"
+#include "cppgc/internal/logging.h"
+#include "cppgc/sentinel-pointer.h"
+#include "v8config.h"  // NOLINT(build/include_directory)
+
+namespace cppgc {
+namespace internal {
+
+#if defined(CPPGC_POINTER_COMPRESSION)
+
+#if defined(__clang__)
+// Attribute const allows the compiler to assume that CageBaseGlobal::g_base_
+// doesn't change (e.g. across calls) and thereby avoid redundant loads.
+#define CPPGC_CONST __attribute__((const))
+#define CPPGC_REQUIRE_CONSTANT_INIT \
+  __attribute__((require_constant_initialization))
+#else  // defined(__clang__)
+#define CPPGC_CONST
+#define CPPGC_REQUIRE_CONSTANT_INIT
+#endif  // defined(__clang__)
+
+class CageBaseGlobal final {
+ public:
+  V8_INLINE CPPGC_CONST static uintptr_t Get() {
+    CPPGC_DCHECK(IsBaseConsistent());
+    return g_base_;
+  }
+
+  V8_INLINE CPPGC_CONST static bool IsSet() {
+    CPPGC_DCHECK(IsBaseConsistent());
+    return (g_base_ & ~kLowerHalfWordMask) != 0;
+  }
+
+ private:
+  // We keep the lower halfword as ones to speed up decompression.
+  static constexpr uintptr_t kLowerHalfWordMask =
+      (api_constants::kCagedHeapReservationAlignment - 1);
+
+  static V8_EXPORT uintptr_t g_base_ CPPGC_REQUIRE_CONSTANT_INIT;
+
+  CageBaseGlobal() = delete;
+
+  V8_INLINE static bool IsBaseConsistent() {
+    return kLowerHalfWordMask == (g_base_ & kLowerHalfWordMask);
+  }
+
+  friend class CageBaseGlobalUpdater;
+};
+
+#undef CPPGC_REQUIRE_CONSTANT_INIT
+#undef CPPGC_CONST
+
+class CompressedPointer final {
+ public:
+  using IntegralType = uint32_t;
+
+  V8_INLINE CompressedPointer() : value_(0u) {}
+  V8_INLINE explicit CompressedPointer(const void* ptr)
+      : value_(Compress(ptr)) {}
+  V8_INLINE explicit CompressedPointer(std::nullptr_t) : value_(0u) {}
+  V8_INLINE explicit CompressedPointer(SentinelPointer)
+      : value_(kCompressedSentinel) {}
+
+  V8_INLINE const void* Load() const { return Decompress(value_); }
+  V8_INLINE const void* LoadAtomic() const {
+    return Decompress(
+        reinterpret_cast<const std::atomic<IntegralType>&>(value_).load(
+            std::memory_order_relaxed));
+  }
+
+  V8_INLINE void Store(const void* ptr) { value_ = Compress(ptr); }
+  V8_INLINE void StoreAtomic(const void* value) {
+    reinterpret_cast<std::atomic<IntegralType>&>(value_).store(
+        Compress(value), std::memory_order_relaxed);
+  }
+
+  V8_INLINE void Clear() { value_ = 0u; }
+  V8_INLINE bool IsCleared() const { return !value_; }
+
+  V8_INLINE bool IsSentinel() const { return value_ == kCompressedSentinel; }
+
+  V8_INLINE uint32_t GetAsInteger() const { return value_; }
+
+  V8_INLINE friend bool operator==(CompressedPointer a, CompressedPointer b) {
+    return a.value_ == b.value_;
+  }
+  V8_INLINE friend bool operator!=(CompressedPointer a, CompressedPointer b) {
+    return a.value_ != b.value_;
+  }
+  V8_INLINE friend bool operator<(CompressedPointer a, CompressedPointer b) {
+    return a.value_ < b.value_;
+  }
+  V8_INLINE friend bool operator<=(CompressedPointer a, CompressedPointer b) {
+    return a.value_ <= b.value_;
+  }
+  V8_INLINE friend bool operator>(CompressedPointer a, CompressedPointer b) {
+    return a.value_ > b.value_;
+  }
+  V8_INLINE friend bool operator>=(CompressedPointer a, CompressedPointer b) {
+    return a.value_ >= b.value_;
+  }
+
+  static V8_INLINE IntegralType Compress(const void* ptr) {
+    static_assert(
+        SentinelPointer::kSentinelValue == 0b10,
+        "The compression scheme relies on the sentinel encoded as 0b10");
+    static constexpr size_t kGigaCageMask =
+        ~(api_constants::kCagedHeapReservationAlignment - 1);
+
+    CPPGC_DCHECK(CageBaseGlobal::IsSet());
+    const uintptr_t base = CageBaseGlobal::Get();
+    CPPGC_DCHECK(!ptr || ptr == kSentinelPointer ||
+                 (base & kGigaCageMask) ==
+                     (reinterpret_cast<uintptr_t>(ptr) & kGigaCageMask));
+
+    const auto uptr = reinterpret_cast<uintptr_t>(ptr);
+    // Shift the pointer by one and truncate.
+    auto compressed = static_cast<IntegralType>(uptr >> 1);
+    // Normal compressed pointers must have the MSB set.
+    CPPGC_DCHECK((!compressed || compressed == kCompressedSentinel) ||
+                 (compressed & 0x80000000));
+    return compressed;
+  }
+
+  static V8_INLINE void* Decompress(IntegralType ptr) {
+    CPPGC_DCHECK(CageBaseGlobal::IsSet());
+    const uintptr_t base = CageBaseGlobal::Get();
+    // Treat compressed pointer as signed and cast it to uint64_t, which will
+    // sign-extend it. Then, shift the result by one. It's important to shift
+    // the unsigned value, as otherwise it would result in undefined behavior.
+    const uint64_t mask = static_cast<uint64_t>(static_cast<int32_t>(ptr)) << 1;
+    return reinterpret_cast<void*>(mask & base);
+  }
+
+ private:
+  static constexpr IntegralType kCompressedSentinel =
+      SentinelPointer::kSentinelValue >> 1;
+  // All constructors initialize `value_`. Do not add a default value here as it
+  // results in a non-atomic write on some builds, even when the atomic version
+  // of the constructor is used.
+  IntegralType value_;
+};
+
+#endif  // defined(CPPGC_POINTER_COMPRESSION)
+
+class RawPointer final {
+ public:
+  using IntegralType = uintptr_t;
+
+  V8_INLINE RawPointer() : ptr_(nullptr) {}
+  V8_INLINE explicit RawPointer(const void* ptr) : ptr_(ptr) {}
+
+  V8_INLINE const void* Load() const { return ptr_; }
+  V8_INLINE const void* LoadAtomic() const {
+    return reinterpret_cast<const std::atomic<const void*>&>(ptr_).load(
+        std::memory_order_relaxed);
+  }
+
+  V8_INLINE void Store(const void* ptr) { ptr_ = ptr; }
+  V8_INLINE void StoreAtomic(const void* ptr) {
+    reinterpret_cast<std::atomic<const void*>&>(ptr_).store(
+        ptr, std::memory_order_relaxed);
+  }
+
+  V8_INLINE void Clear() { ptr_ = nullptr; }
+  V8_INLINE bool IsCleared() const { return !ptr_; }
+
+  V8_INLINE bool IsSentinel() const { return ptr_ == kSentinelPointer; }
+
+  V8_INLINE uintptr_t GetAsInteger() const {
+    return reinterpret_cast<uintptr_t>(ptr_);
+  }
+
+  V8_INLINE friend bool operator==(RawPointer a, RawPointer b) {
+    return a.ptr_ == b.ptr_;
+  }
+  V8_INLINE friend bool operator!=(RawPointer a, RawPointer b) {
+    return a.ptr_ != b.ptr_;
+  }
+  V8_INLINE friend bool operator<(RawPointer a, RawPointer b) {
+    return a.ptr_ < b.ptr_;
+  }
+  V8_INLINE friend bool operator<=(RawPointer a, RawPointer b) {
+    return a.ptr_ <= b.ptr_;
+  }
+  V8_INLINE friend bool operator>(RawPointer a, RawPointer b) {
+    return a.ptr_ > b.ptr_;
+  }
+  V8_INLINE friend bool operator>=(RawPointer a, RawPointer b) {
+    return a.ptr_ >= b.ptr_;
+  }
+
+ private:
+  // All constructors initialize `ptr_`. Do not add a default value here as it
+  // results in a non-atomic write on some builds, even when the atomic version
+  // of the constructor is used.
+  const void* ptr_;
+};
+
+#if defined(CPPGC_POINTER_COMPRESSION)
+using MemberStorage = CompressedPointer;
+#else   // !defined(CPPGC_POINTER_COMPRESSION)
+using MemberStorage = RawPointer;
+#endif  // !defined(CPPGC_POINTER_COMPRESSION)
+
+}  // namespace internal
+}  // namespace cppgc
+
+#endif  // INCLUDE_CPPGC_INTERNAL_MEMBER_STORAGE_H_

--- a/include/cppgc/member.h
+++ b/include/cppgc/member.h
@@ -10,6 +10,7 @@
 #include <type_traits>
 
 #include "cppgc/internal/api-constants.h"
+#include "cppgc/internal/member-storage.h"
 #include "cppgc/internal/pointer-policies.h"
 #include "cppgc/sentinel-pointer.h"
 #include "cppgc/type-traits.h"
@@ -17,200 +18,13 @@
 
 namespace cppgc {
 
+namespace subtle {
+class HeapConsistency;
+}  // namespace subtle
+
 class Visitor;
 
 namespace internal {
-
-#if defined(CPPGC_POINTER_COMPRESSION)
-
-#if defined(__clang__)
-// Attribute const allows the compiler to assume that CageBaseGlobal::g_base_
-// doesn't change (e.g. across calls) and thereby avoid redundant loads.
-#define CPPGC_CONST __attribute__((const))
-#define CPPGC_REQUIRE_CONSTANT_INIT \
-  __attribute__((require_constant_initialization))
-#else  // defined(__clang__)
-#define CPPGC_CONST
-#define CPPGC_REQUIRE_CONSTANT_INIT
-#endif  // defined(__clang__)
-
-class CageBaseGlobal final {
- public:
-  V8_INLINE CPPGC_CONST static uintptr_t Get() {
-    CPPGC_DCHECK(IsBaseConsistent());
-    return g_base_;
-  }
-
-  V8_INLINE CPPGC_CONST static bool IsSet() {
-    CPPGC_DCHECK(IsBaseConsistent());
-    return (g_base_ & ~kLowerHalfWordMask) != 0;
-  }
-
- private:
-  // We keep the lower halfword as ones to speed up decompression.
-  static constexpr uintptr_t kLowerHalfWordMask =
-      (api_constants::kCagedHeapReservationAlignment - 1);
-
-  static V8_EXPORT uintptr_t g_base_ CPPGC_REQUIRE_CONSTANT_INIT;
-
-  CageBaseGlobal() = delete;
-
-  V8_INLINE static bool IsBaseConsistent() {
-    return kLowerHalfWordMask == (g_base_ & kLowerHalfWordMask);
-  }
-
-  friend class CageBaseGlobalUpdater;
-};
-
-#undef CPPGC_REQUIRE_CONSTANT_INIT
-#undef CPPGC_CONST
-
-class CompressedPointer final {
- public:
-  using IntegralType = uint32_t;
-
-  V8_INLINE CompressedPointer() : value_(0u) {}
-  V8_INLINE explicit CompressedPointer(const void* ptr)
-      : value_(Compress(ptr)) {}
-  V8_INLINE explicit CompressedPointer(std::nullptr_t) : value_(0u) {}
-  V8_INLINE explicit CompressedPointer(SentinelPointer)
-      : value_(kCompressedSentinel) {}
-
-  V8_INLINE const void* Load() const { return Decompress(value_); }
-  V8_INLINE const void* LoadAtomic() const {
-    return Decompress(
-        reinterpret_cast<const std::atomic<IntegralType>&>(value_).load(
-            std::memory_order_relaxed));
-  }
-
-  V8_INLINE void Store(const void* ptr) { value_ = Compress(ptr); }
-  V8_INLINE void StoreAtomic(const void* value) {
-    reinterpret_cast<std::atomic<IntegralType>&>(value_).store(
-        Compress(value), std::memory_order_relaxed);
-  }
-
-  V8_INLINE void Clear() { value_ = 0u; }
-  V8_INLINE bool IsCleared() const { return !value_; }
-
-  V8_INLINE bool IsSentinel() const { return value_ == kCompressedSentinel; }
-
-  V8_INLINE uint32_t GetAsInteger() const { return value_; }
-
-  V8_INLINE friend bool operator==(CompressedPointer a, CompressedPointer b) {
-    return a.value_ == b.value_;
-  }
-  V8_INLINE friend bool operator!=(CompressedPointer a, CompressedPointer b) {
-    return a.value_ != b.value_;
-  }
-  V8_INLINE friend bool operator<(CompressedPointer a, CompressedPointer b) {
-    return a.value_ < b.value_;
-  }
-  V8_INLINE friend bool operator<=(CompressedPointer a, CompressedPointer b) {
-    return a.value_ <= b.value_;
-  }
-  V8_INLINE friend bool operator>(CompressedPointer a, CompressedPointer b) {
-    return a.value_ > b.value_;
-  }
-  V8_INLINE friend bool operator>=(CompressedPointer a, CompressedPointer b) {
-    return a.value_ >= b.value_;
-  }
-
-  static V8_INLINE IntegralType Compress(const void* ptr) {
-    static_assert(
-        SentinelPointer::kSentinelValue == 0b10,
-        "The compression scheme relies on the sentinel encoded as 0b10");
-    static constexpr size_t kGigaCageMask =
-        ~(api_constants::kCagedHeapReservationAlignment - 1);
-
-    CPPGC_DCHECK(CageBaseGlobal::IsSet());
-    const uintptr_t base = CageBaseGlobal::Get();
-    CPPGC_DCHECK(!ptr || ptr == kSentinelPointer ||
-                 (base & kGigaCageMask) ==
-                     (reinterpret_cast<uintptr_t>(ptr) & kGigaCageMask));
-
-    const auto uptr = reinterpret_cast<uintptr_t>(ptr);
-    // Shift the pointer by one and truncate.
-    auto compressed = static_cast<IntegralType>(uptr >> 1);
-    // Normal compressed pointers must have the MSB set.
-    CPPGC_DCHECK((!compressed || compressed == kCompressedSentinel) ||
-                 (compressed & 0x80000000));
-    return compressed;
-  }
-
-  static V8_INLINE void* Decompress(IntegralType ptr) {
-    CPPGC_DCHECK(CageBaseGlobal::IsSet());
-    const uintptr_t base = CageBaseGlobal::Get();
-    // Treat compressed pointer as signed and cast it to uint64_t, which will
-    // sign-extend it. Then, shift the result by one. It's important to shift
-    // the unsigned value, as otherwise it would result in undefined behavior.
-    const uint64_t mask = static_cast<uint64_t>(static_cast<int32_t>(ptr)) << 1;
-    return reinterpret_cast<void*>(mask & base);
-  }
-
- private:
-  static constexpr IntegralType kCompressedSentinel =
-      SentinelPointer::kSentinelValue >> 1;
-  // All constructors initialize `value_`. Do not add a default value here as it
-  // results in a non-atomic write on some builds, even when the atomic version
-  // of the constructor is used.
-  IntegralType value_;
-};
-
-#endif  // defined(CPPGC_POINTER_COMPRESSION)
-
-class RawPointer final {
- public:
-  using IntegralType = uintptr_t;
-
-  V8_INLINE RawPointer() : ptr_(nullptr) {}
-  V8_INLINE explicit RawPointer(const void* ptr) : ptr_(ptr) {}
-
-  V8_INLINE const void* Load() const { return ptr_; }
-  V8_INLINE const void* LoadAtomic() const {
-    return reinterpret_cast<const std::atomic<const void*>&>(ptr_).load(
-        std::memory_order_relaxed);
-  }
-
-  V8_INLINE void Store(const void* ptr) { ptr_ = ptr; }
-  V8_INLINE void StoreAtomic(const void* ptr) {
-    reinterpret_cast<std::atomic<const void*>&>(ptr_).store(
-        ptr, std::memory_order_relaxed);
-  }
-
-  V8_INLINE void Clear() { ptr_ = nullptr; }
-  V8_INLINE bool IsCleared() const { return !ptr_; }
-
-  V8_INLINE bool IsSentinel() const { return ptr_ == kSentinelPointer; }
-
-  V8_INLINE uintptr_t GetAsInteger() const {
-    return reinterpret_cast<uintptr_t>(ptr_);
-  }
-
-  V8_INLINE friend bool operator==(RawPointer a, RawPointer b) {
-    return a.ptr_ == b.ptr_;
-  }
-  V8_INLINE friend bool operator!=(RawPointer a, RawPointer b) {
-    return a.ptr_ != b.ptr_;
-  }
-  V8_INLINE friend bool operator<(RawPointer a, RawPointer b) {
-    return a.ptr_ < b.ptr_;
-  }
-  V8_INLINE friend bool operator<=(RawPointer a, RawPointer b) {
-    return a.ptr_ <= b.ptr_;
-  }
-  V8_INLINE friend bool operator>(RawPointer a, RawPointer b) {
-    return a.ptr_ > b.ptr_;
-  }
-  V8_INLINE friend bool operator>=(RawPointer a, RawPointer b) {
-    return a.ptr_ >= b.ptr_;
-  }
-
- private:
-  // All constructors initialize `ptr_`. Do not add a default value here as it
-  // results in a non-atomic write on some builds, even when the atomic version
-  // of the constructor is used.
-  const void* ptr_;
-};
 
 // MemberBase always refers to the object as const object and defers to
 // BasicMember on casting to the right type as needed.
@@ -474,7 +288,7 @@ class BasicMember final : private MemberBase, private CheckingPolicy {
 
   V8_INLINE BasicMember& operator=(RawStorage other) {
     SetRawStorageAtomic(other);
-    AssigningWriteBarrier(Get());
+    AssigningWriteBarrier();
     this->CheckPointer(Get());
     return *this;
   }
@@ -489,11 +303,15 @@ class BasicMember final : private MemberBase, private CheckingPolicy {
   V8_INLINE void AssigningWriteBarrier(T* value) const {
     WriteBarrierPolicy::AssigningBarrier(GetRawSlot(), value);
   }
+  V8_INLINE void AssigningWriteBarrier() const {
+    WriteBarrierPolicy::AssigningBarrier(GetRawSlot(), GetRawStorage());
+  }
 
   V8_INLINE void ClearFromGC() const { MemberBase::ClearFromGC(); }
 
   V8_INLINE T* GetFromGC() const { return Get(); }
 
+  friend class cppgc::subtle::HeapConsistency;
   friend class cppgc::Visitor;
   template <typename U>
   friend struct cppgc::TraceTrait;

--- a/include/cppgc/persistent.h
+++ b/include/cppgc/persistent.h
@@ -16,9 +16,6 @@
 #include "v8config.h"  // NOLINT(build/include_directory)
 
 namespace cppgc {
-
-class Visitor;
-
 namespace internal {
 
 // PersistentBase always refers to the object as const object and defers to
@@ -78,7 +75,7 @@ class BasicPersistent final : public PersistentBase,
       : PersistentBase(raw), LocationPolicy(loc) {
     if (!IsValid()) return;
     SetNode(WeaknessPolicy::GetPersistentRegion(GetValue())
-                .AllocateNode(this, &BasicPersistent::Trace));
+                .AllocateNode(this, &TraceAsRoot));
     this->CheckPointer(Get());
   }
 
@@ -221,9 +218,8 @@ class BasicPersistent final : public PersistentBase,
   }
 
  private:
-  static void Trace(Visitor* v, const void* ptr) {
-    const auto* persistent = static_cast<const BasicPersistent*>(ptr);
-    v->TraceRoot(*persistent, persistent->Location());
+  static void TraceAsRoot(RootVisitor& root_visitor, const void* ptr) {
+    root_visitor.Trace(*static_cast<const BasicPersistent*>(ptr));
   }
 
   bool IsValid() const {
@@ -247,7 +243,7 @@ class BasicPersistent final : public PersistentBase,
     SetValue(ptr);
     if (!IsValid()) return;
     SetNode(WeaknessPolicy::GetPersistentRegion(GetValue())
-                .AllocateNode(this, &BasicPersistent::Trace));
+                .AllocateNode(this, &TraceAsRoot));
     this->CheckPointer(Get());
   }
 
@@ -264,7 +260,7 @@ class BasicPersistent final : public PersistentBase,
     return static_cast<T*>(const_cast<void*>(GetValue()));
   }
 
-  friend class cppgc::Visitor;
+  friend class internal::RootVisitor;
 };
 
 template <typename T1, typename WeaknessPolicy1, typename LocationPolicy1,

--- a/include/cppgc/trace-trait.h
+++ b/include/cppgc/trace-trait.h
@@ -16,6 +16,10 @@ class Visitor;
 
 namespace internal {
 
+class RootVisitor;
+
+using TraceRootCallback = void (*)(RootVisitor&, const void* object);
+
 // Implementation of the default TraceTrait handling GarbageCollected and
 // GarbageCollectedMixin.
 template <typename T,

--- a/include/cppgc/visitor.h
+++ b/include/cppgc/visitor.h
@@ -68,14 +68,9 @@ class V8_EXPORT Visitor {
    * \param member Reference retaining an object.
    */
   template <typename T>
+  V8_DEPRECATED("Do not use Trace() with raw pointers.")
   void Trace(const T* t) {
-    static_assert(sizeof(T), "Pointee type must be fully defined.");
-    static_assert(internal::IsGarbageCollectedOrMixinType<T>::value,
-                  "T must be GarbageCollected or GarbageCollectedMixin type");
-    if (!t) {
-      return;
-    }
-    Visit(t, TraceTrait<T>::GetTraceDescriptor(t));
+    TraceImpl(t);
   }
 
   /**
@@ -87,7 +82,7 @@ class V8_EXPORT Visitor {
   void Trace(const Member<T>& member) {
     const T* value = member.GetRawAtomic();
     CPPGC_DCHECK(value != kSentinelPointer);
-    Trace(value);
+    TraceImpl(value);
   }
 
   /**
@@ -231,23 +226,33 @@ class V8_EXPORT Visitor {
   void TraceStrongly(const WeakMember<T>& weak_member) {
     const T* value = weak_member.GetRawAtomic();
     CPPGC_DCHECK(value != kSentinelPointer);
-    Trace(value);
+    TraceImpl(value);
   }
 
   /**
-   * Trace method for weak containers.
+   * Trace method for retaining containers strongly.
    *
-   * \param object reference of the weak container.
+   * \param object reference to the container.
+   */
+  template <typename T>
+  void TraceStrongContainer(const T* object) {
+    TraceImpl(object);
+  }
+
+  /**
+   * Trace method for retaining containers weakly.
+   *
+   * \param object reference to the container.
    * \param callback to be invoked.
-   * \param data custom data that is passed to the callback.
+   * \param callback_data custom data that is passed to the callback.
    */
   template <typename T>
   void TraceWeakContainer(const T* object, WeakCallback callback,
-                          const void* data) {
+                          const void* callback_data) {
     if (!object) return;
     VisitWeakContainer(object, TraceTrait<T>::GetTraceDescriptor(object),
                        TraceTrait<T>::GetWeakTraceDescriptor(object), callback,
-                       data);
+                       callback_data);
   }
 
   /**
@@ -298,9 +303,6 @@ class V8_EXPORT Visitor {
   virtual void Visit(const void* self, TraceDescriptor) {}
   virtual void VisitWeak(const void* self, TraceDescriptor, WeakCallback,
                          const void* weak_member) {}
-  virtual void VisitRoot(const void*, TraceDescriptor, const SourceLocation&) {}
-  virtual void VisitWeakRoot(const void* self, TraceDescriptor, WeakCallback,
-                             const void* weak_root, const SourceLocation&) {}
   virtual void VisitEphemeron(const void* key, const void* value,
                               TraceDescriptor value_desc) {}
   virtual void VisitWeakContainer(const void* self, TraceDescriptor strong_desc,
@@ -321,44 +323,20 @@ class V8_EXPORT Visitor {
   static void HandleWeak(const LivenessBroker& info, const void* object) {
     const PointerType* weak = static_cast<const PointerType*>(object);
     auto* raw_ptr = weak->GetFromGC();
-    // Sentinel values are preserved for weak pointers.
-    if (raw_ptr == kSentinelPointer) return;
     if (!info.IsHeapObjectAlive(raw_ptr)) {
       weak->ClearFromGC();
     }
   }
 
-  template <typename Persistent,
-            std::enable_if_t<Persistent::IsStrongPersistent::value>* = nullptr>
-  void TraceRoot(const Persistent& p, const SourceLocation& loc) {
-    using PointeeType = typename Persistent::PointeeType;
-    static_assert(sizeof(PointeeType),
-                  "Persistent's pointee type must be fully defined");
-    static_assert(internal::IsGarbageCollectedOrMixinType<PointeeType>::value,
-                  "Persistent's pointee type must be GarbageCollected or "
-                  "GarbageCollectedMixin");
-    auto* ptr = p.GetFromGC();
-    if (!ptr) {
+  template <typename T>
+  void TraceImpl(const T* t) {
+    static_assert(sizeof(T), "Pointee type must be fully defined.");
+    static_assert(internal::IsGarbageCollectedOrMixinType<T>::value,
+                  "T must be GarbageCollected or GarbageCollectedMixin type");
+    if (!t) {
       return;
     }
-    VisitRoot(ptr, TraceTrait<PointeeType>::GetTraceDescriptor(ptr), loc);
-  }
-
-  template <
-      typename WeakPersistent,
-      std::enable_if_t<!WeakPersistent::IsStrongPersistent::value>* = nullptr>
-  void TraceRoot(const WeakPersistent& p, const SourceLocation& loc) {
-    using PointeeType = typename WeakPersistent::PointeeType;
-    static_assert(sizeof(PointeeType),
-                  "Persistent's pointee type must be fully defined");
-    static_assert(internal::IsGarbageCollectedOrMixinType<PointeeType>::value,
-                  "Persistent's pointee type must be GarbageCollected or "
-                  "GarbageCollectedMixin");
-    static_assert(!internal::IsAllocatedOnCompactableSpace<PointeeType>::value,
-                  "Weak references to compactable objects are not allowed");
-    auto* ptr = p.GetFromGC();
-    VisitWeakRoot(ptr, TraceTrait<PointeeType>::GetTraceDescriptor(ptr),
-                  &HandleWeak<WeakPersistent>, &p, loc);
+    Visit(t, TraceTrait<T>::GetTraceDescriptor(t));
   }
 
 #if V8_ENABLE_CHECKS
@@ -375,6 +353,70 @@ class V8_EXPORT Visitor {
   friend class internal::VisitorBase;
 };
 
+namespace internal {
+
+class V8_EXPORT RootVisitor {
+ public:
+  explicit RootVisitor(Visitor::Key) {}
+
+  virtual ~RootVisitor() = default;
+
+  template <typename AnyStrongPersistentType,
+            std::enable_if_t<
+                AnyStrongPersistentType::IsStrongPersistent::value>* = nullptr>
+  void Trace(const AnyStrongPersistentType& p) {
+    using PointeeType = typename AnyStrongPersistentType::PointeeType;
+    const void* object = Extract(p);
+    if (!object) {
+      return;
+    }
+    VisitRoot(object, TraceTrait<PointeeType>::GetTraceDescriptor(object),
+              p.Location());
+  }
+
+  template <typename AnyWeakPersistentType,
+            std::enable_if_t<
+                !AnyWeakPersistentType::IsStrongPersistent::value>* = nullptr>
+  void Trace(const AnyWeakPersistentType& p) {
+    using PointeeType = typename AnyWeakPersistentType::PointeeType;
+    static_assert(!internal::IsAllocatedOnCompactableSpace<PointeeType>::value,
+                  "Weak references to compactable objects are not allowed");
+    const void* object = Extract(p);
+    if (!object) {
+      return;
+    }
+    VisitWeakRoot(object, TraceTrait<PointeeType>::GetTraceDescriptor(object),
+                  &HandleWeak<AnyWeakPersistentType>, &p, p.Location());
+  }
+
+ protected:
+  virtual void VisitRoot(const void*, TraceDescriptor, const SourceLocation&) {}
+  virtual void VisitWeakRoot(const void* self, TraceDescriptor, WeakCallback,
+                             const void* weak_root, const SourceLocation&) {}
+
+ private:
+  template <typename AnyPersistentType>
+  static const void* Extract(AnyPersistentType& p) {
+    using PointeeType = typename AnyPersistentType::PointeeType;
+    static_assert(sizeof(PointeeType),
+                  "Persistent's pointee type must be fully defined");
+    static_assert(internal::IsGarbageCollectedOrMixinType<PointeeType>::value,
+                  "Persistent's pointee type must be GarbageCollected or "
+                  "GarbageCollectedMixin");
+    return p.GetFromGC();
+  }
+
+  template <typename PointerType>
+  static void HandleWeak(const LivenessBroker& info, const void* object) {
+    const PointerType* weak = static_cast<const PointerType*>(object);
+    auto* raw_ptr = weak->GetFromGC();
+    if (!info.IsHeapObjectAlive(raw_ptr)) {
+      weak->ClearFromGC();
+    }
+  }
+};
+
+}  // namespace internal
 }  // namespace cppgc
 
 #endif  // INCLUDE_CPPGC_VISITOR_H_

--- a/include/v8-platform.h
+++ b/include/v8-platform.h
@@ -924,10 +924,7 @@ class Platform {
   /**
    * Allows the embedder to manage memory page allocations.
    */
-  virtual PageAllocator* GetPageAllocator() {
-    // TODO(bbudge) Make this abstract after all embedders implement this.
-    return nullptr;
-  }
+  virtual PageAllocator* GetPageAllocator() = 0;
 
   /**
    * Allows the embedder to specify a custom allocator used for zones.
@@ -944,10 +941,7 @@ class Platform {
    * error.
    * Embedder overrides of this function must NOT call back into V8.
    */
-  virtual void OnCriticalMemoryPressure() {
-    // TODO(bbudge) Remove this when embedders override the following method.
-    // See crbug.com/634547.
-  }
+  virtual void OnCriticalMemoryPressure() {}
 
   /**
    * Enables the embedder to respond in cases where V8 can't allocate large
@@ -958,6 +952,7 @@ class Platform {
    *
    * Embedder overrides of this function must NOT call back into V8.
    */
+  V8_DEPRECATE_SOON("Use the method without informative parameter")
   virtual bool OnCriticalMemoryPressure(size_t length) { return false; }
 
   /**
@@ -1076,13 +1071,9 @@ class Platform {
    *    return v8::platform::NewDefaultJobHandle(
    *        this, priority, std::move(job_task), NumberOfWorkerThreads());
    * }
-   *
-   * TODO(etiennep): Make pure virtual once custom embedders implement it.
    */
   virtual std::unique_ptr<JobHandle> CreateJob(
-      TaskPriority priority, std::unique_ptr<JobTask> job_task) {
-    return nullptr;
-  }
+      TaskPriority priority, std::unique_ptr<JobTask> job_task) = 0;
 
   /**
    * Monotonically increasing time in seconds from an arbitrary fixed point in

--- a/include/v8config.h
+++ b/include/v8config.h
@@ -357,6 +357,7 @@ path. Add it with -I<path> to the command line
 # define V8_HAS_BUILTIN_SADD_OVERFLOW (__has_builtin(__builtin_sadd_overflow))
 # define V8_HAS_BUILTIN_SSUB_OVERFLOW (__has_builtin(__builtin_ssub_overflow))
 # define V8_HAS_BUILTIN_UADD_OVERFLOW (__has_builtin(__builtin_uadd_overflow))
+# define V8_HAS_BUILTIN_UNREACHABLE (__has_builtin(__builtin_unreachable))
 
 // Clang has no __has_feature for computed gotos.
 // GCC doc: https://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html
@@ -395,6 +396,7 @@ path. Add it with -I<path> to the command line
 # define V8_HAS_BUILTIN_EXPECT 1
 # define V8_HAS_BUILTIN_FRAME_ADDRESS 1
 # define V8_HAS_BUILTIN_POPCOUNT 1
+# define V8_HAS_BUILTIN_UNREACHABLE 1
 
 // GCC doc: https://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html
 #define V8_HAS_COMPUTED_GOTO 1
@@ -431,6 +433,9 @@ path. Add it with -I<path> to the command line
 # define V8_ASSUME(condition) DCHECK(condition)
 #elif V8_HAS_BUILTIN_ASSUME
 # define V8_ASSUME(condition) __builtin_assume(condition)
+#elif V8_HAS_BUILTIN_UNREACHABLE
+# define V8_ASSUME(condition) \
+  do { if (!(condition)) __builtin_unreachable(); } while (false)
 #else
 # define V8_ASSUME(condition)
 #endif
@@ -479,6 +484,34 @@ path. Add it with -I<path> to the command line
 #else
 # define V8_DEPRECATE_SOON(message)
 #endif
+
+
+#if defined(V8_IMMINENT_DEPRECATION_WARNINGS) || \
+    defined(V8_DEPRECATION_WARNINGS)
+#if defined(V8_CC_MSVC)
+# define START_ALLOW_USE_DEPRECATED() \
+    __pragma(warning(push))           \
+    __pragma(warning(disable : 4996))
+# define END_ALLOW_USE_DEPRECATED() __pragma(warning(pop))
+#else  // !defined(V8_CC_MSVC)
+# define START_ALLOW_USE_DEPRECATED()                               \
+    _Pragma("GCC diagnostic push")                                  \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define END_ALLOW_USE_DEPRECATED() _Pragma("GCC diagnostic pop")
+#endif  // !defined(V8_CC_MSVC)
+#else  // !(defined(V8_IMMINENT_DEPRECATION_WARNINGS) ||
+       // defined(V8_DEPRECATION_WARNINGS))
+#define START_ALLOW_USE_DEPRECATED()
+#define END_ALLOW_USE_DEPRECATED()
+#endif  // !(defined(V8_IMMINENT_DEPRECATION_WARNINGS) ||
+        // defined(V8_DEPRECATION_WARNINGS))
+#define ALLOW_COPY_AND_MOVE_WITH_DEPRECATED_FIELDS(ClassName) \
+  START_ALLOW_USE_DEPRECATED()                                \
+  ClassName(const ClassName&) = default;                      \
+  ClassName(ClassName&&) = default;                           \
+  ClassName& operator=(const ClassName&) = default;           \
+  ClassName& operator=(ClassName&&) = default;                \
+  END_ALLOW_USE_DEPRECATED()
 
 
 #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 6)
@@ -590,13 +623,6 @@ V8 shared library set USING_V8_SHARED.
 
 #endif  // V8_OS_WIN
 
-// From C++17 onwards, static constexpr member variables are defined to be
-// "inline", and adding a separate definition for them can trigger deprecation
-// warnings. For C++14 and below, however, these definitions are required.
-#if __cplusplus < 201703L && (!defined(_MSVC_LANG) || _MSVC_LANG < 201703L)
-#define V8_STATIC_CONSTEXPR_VARIABLES_NEED_DEFINITIONS
-#endif
-
 // clang-format on
 
 // Processor architecture detection.  For more info on what's defined, see:
@@ -648,6 +674,9 @@ V8 shared library set USING_V8_SHARED.
 #if __riscv_xlen == 64
 #define V8_HOST_ARCH_RISCV64 1
 #define V8_HOST_ARCH_64_BIT 1
+#elif __riscv_xlen == 32
+#define V8_HOST_ARCH_RISCV32 1
+#define V8_HOST_ARCH_32_BIT 1
 #else
 #error "Cannot detect Riscv's bitwidth"
 #endif
@@ -663,7 +692,8 @@ V8 shared library set USING_V8_SHARED.
 #if !V8_TARGET_ARCH_X64 && !V8_TARGET_ARCH_IA32 && !V8_TARGET_ARCH_ARM &&      \
     !V8_TARGET_ARCH_ARM64 && !V8_TARGET_ARCH_MIPS && !V8_TARGET_ARCH_MIPS64 && \
     !V8_TARGET_ARCH_PPC && !V8_TARGET_ARCH_PPC64 && !V8_TARGET_ARCH_S390 &&    \
-    !V8_TARGET_ARCH_RISCV64 && !V8_TARGET_ARCH_LOONG64
+    !V8_TARGET_ARCH_RISCV64 && !V8_TARGET_ARCH_LOONG64 &&                      \
+    !V8_TARGET_ARCH_RISCV32
 #if defined(_M_X64) || defined(__x86_64__)
 #define V8_TARGET_ARCH_X64 1
 #elif defined(_M_IX86) || defined(__i386__)
@@ -688,6 +718,8 @@ V8 shared library set USING_V8_SHARED.
 #elif defined(__riscv) || defined(__riscv__)
 #if __riscv_xlen == 64
 #define V8_TARGET_ARCH_RISCV64 1
+#elif __riscv_xlen == 32
+#define V8_TARGET_ARCH_RISCV32 1
 #endif
 #else
 #error Target architecture was not detected as supported by v8
@@ -727,6 +759,8 @@ V8 shared library set USING_V8_SHARED.
 #endif
 #elif V8_TARGET_ARCH_RISCV64
 #define V8_TARGET_ARCH_64_BIT 1
+#elif V8_TARGET_ARCH_RISCV32
+#define V8_TARGET_ARCH_32_BIT 1
 #else
 #error Unknown target architecture pointer size
 #endif
@@ -757,6 +791,9 @@ V8 shared library set USING_V8_SHARED.
 #endif
 #if (V8_TARGET_ARCH_RISCV64 && !(V8_HOST_ARCH_X64 || V8_HOST_ARCH_RISCV64))
 #error Target architecture riscv64 is only supported on riscv64 and x64 host
+#endif
+#if (V8_TARGET_ARCH_RISCV32 && !(V8_HOST_ARCH_IA32 || V8_HOST_ARCH_RISCV32))
+#error Target architecture riscv32 is only supported on riscv32 and ia32 host
 #endif
 #if (V8_TARGET_ARCH_LOONG64 && !(V8_HOST_ARCH_X64 || V8_HOST_ARCH_LOONG64))
 #error Target architecture loong64 is only supported on loong64 and x64 host
@@ -797,7 +834,7 @@ V8 shared library set USING_V8_SHARED.
 #else
 #define V8_TARGET_BIG_ENDIAN 1
 #endif
-#elif V8_TARGET_ARCH_RISCV64
+#elif V8_TARGET_ARCH_RISCV32 || V8_TARGET_ARCH_RISCV64
 #define V8_TARGET_LITTLE_ENDIAN 1
 #elif defined(__BYTE_ORDER__)
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__

--- a/src/base/bit-field.h
+++ b/src/base/bit-field.h
@@ -40,6 +40,11 @@ class BitField final {
   static constexpr U kNumValues = U{1} << kSize;
 
   // Value for the field with all bits set.
+  // If clang complains
+  // "constexpr variable 'kMax' must be initialized by a constant expression"
+  // on this line, then you're creating a BitField for an enum with more bits
+  // than needed for the enum values. Either reduce the BitField size,
+  // or give the enum an explicit underlying type.
   static constexpr T kMax = static_cast<T>(kNumValues - 1);
 
   template <class T2, int size2>

--- a/src/base/build_config.h
+++ b/src/base/build_config.h
@@ -34,6 +34,12 @@
 #define V8_HAS_PTHREAD_JIT_WRITE_PROTECT 0
 #endif
 
+#if defined(V8_OS_LINUX) && defined(V8_HOST_ARCH_X64)
+#define V8_HAS_PKU_JIT_WRITE_PROTECT 1
+#else
+#define V8_HAS_PKU_JIT_WRITE_PROTECT 0
+#endif
+
 #if defined(V8_TARGET_ARCH_IA32) || defined(V8_TARGET_ARCH_X64)
 #define V8_TARGET_ARCH_STORES_RETURN_ADDRESS_ON_STACK true
 #else

--- a/src/base/compiler-specific.h
+++ b/src/base/compiler-specific.h
@@ -98,10 +98,10 @@
 // do not support adding noexcept to default members.
 // Disabled on MSVC because constructors of standard containers are not noexcept
 // there.
-#if ((!defined(V8_CC_GNU) && !defined(V8_CC_MSVC) &&                      \
-      !defined(V8_TARGET_ARCH_MIPS) && !defined(V8_TARGET_ARCH_MIPS64) && \
-      !defined(V8_TARGET_ARCH_PPC) && !defined(V8_TARGET_ARCH_PPC64) &&   \
-      !defined(V8_TARGET_ARCH_RISCV64)) ||                                \
+#if ((!defined(V8_CC_GNU) && !defined(V8_CC_MSVC) &&                           \
+      !defined(V8_TARGET_ARCH_MIPS) && !defined(V8_TARGET_ARCH_MIPS64) &&      \
+      !defined(V8_TARGET_ARCH_PPC) && !defined(V8_TARGET_ARCH_PPC64) &&        \
+      !defined(V8_TARGET_ARCH_RISCV64) && !defined(V8_TARGET_ARCH_RISCV32)) || \
      (defined(__clang__) && __cplusplus > 201300L))
 #define V8_NOEXCEPT noexcept
 #else

--- a/src/base/platform/memory-protection-key.cc
+++ b/src/base/platform/memory-protection-key.cc
@@ -4,7 +4,7 @@
 
 #include "src/base/platform/memory-protection-key.h"
 
-#if defined(V8_OS_LINUX) && defined(V8_HOST_ARCH_X64)
+#if V8_HAS_PKU_JIT_WRITE_PROTECT
 #include <sys/mman.h>     // For {mprotect()} protection macros.
 #include <sys/utsname.h>  // For {uname()}.
 #undef MAP_TYPE  // Conflicts with MAP_TYPE in Torque-generated instance-types.h
@@ -34,7 +34,7 @@
 // TODO(dlehmann): Move this import and freestanding functions below to
 // base/platform/platform.h {OS} (lower-level functions) and
 // {base::PageAllocator} (exported API).
-#if defined(V8_OS_LINUX) && defined(V8_HOST_ARCH_X64)
+#if V8_HAS_PKU_JIT_WRITE_PROTECT
 #include <dlfcn.h>
 #endif
 
@@ -55,11 +55,11 @@ pkey_get_t pkey_get = nullptr;
 pkey_set_t pkey_set = nullptr;
 
 #ifdef DEBUG
-bool pkey_initialized = false;
+bool pkey_api_initialized = false;
 #endif
 
 int GetProtectionFromMemoryPermission(PageAllocator::Permission permission) {
-#if defined(V8_OS_LINUX) && defined(V8_HOST_ARCH_X64)
+#if V8_HAS_PKU_JIT_WRITE_PROTECT
   // Mappings for PKU are either RWX (for code), no access (for uncommitted
   // memory), or RW (for assembler buffers).
   switch (permission) {
@@ -80,9 +80,9 @@ int GetProtectionFromMemoryPermission(PageAllocator::Permission permission) {
 }  // namespace
 
 void MemoryProtectionKey::InitializeMemoryProtectionKeySupport() {
-  // Flip {pkey_initialized} (in debug mode) and check the new value.
-  DCHECK_EQ(true, pkey_initialized = !pkey_initialized);
-#if defined(V8_OS_LINUX) && defined(V8_HOST_ARCH_X64)
+  // Flip {pkey_api_initialized} (in debug mode) and check the new value.
+  DCHECK_EQ(true, pkey_api_initialized = !pkey_api_initialized);
+#if V8_HAS_PKU_JIT_WRITE_PROTECT
   // PKU was broken on Linux kernels before 5.13 (see
   // https://lore.kernel.org/all/20210623121456.399107624@linutronix.de/).
   // A fix is also included in the 5.4.182 and 5.10.103 versions ("x86/fpu:
@@ -136,7 +136,7 @@ void MemoryProtectionKey::InitializeMemoryProtectionKeySupport() {
 // static
 DISABLE_CFI_ICALL
 int MemoryProtectionKey::AllocateKey() {
-  DCHECK(pkey_initialized);
+  DCHECK(pkey_api_initialized);
   if (!pkey_alloc) return kNoMemoryProtectionKey;
 
   // If there is support in glibc, try to allocate a new key.
@@ -153,7 +153,7 @@ int MemoryProtectionKey::AllocateKey() {
 // static
 DISABLE_CFI_ICALL
 void MemoryProtectionKey::FreeKey(int key) {
-  DCHECK(pkey_initialized);
+  DCHECK(pkey_api_initialized);
   // Only free the key if one was allocated.
   if (key == kNoMemoryProtectionKey) return;
 
@@ -168,7 +168,7 @@ DISABLE_CFI_ICALL
 bool MemoryProtectionKey::SetPermissionsAndKey(
     v8::PageAllocator* page_allocator, base::AddressRegion region,
     v8::PageAllocator::Permission page_permissions, int key) {
-  DCHECK(pkey_initialized);
+  DCHECK(pkey_api_initialized);
 
   void* address = reinterpret_cast<void*>(region.begin());
   size_t size = region.size();
@@ -207,7 +207,7 @@ bool MemoryProtectionKey::SetPermissionsAndKey(
 DISABLE_CFI_ICALL
 void MemoryProtectionKey::SetPermissionsForKey(int key,
                                                Permission permissions) {
-  DCHECK(pkey_initialized);
+  DCHECK(pkey_api_initialized);
   DCHECK_NE(kNoMemoryProtectionKey, key);
 
   // If a valid key was allocated, {pkey_set()} must also be available.
@@ -219,7 +219,7 @@ void MemoryProtectionKey::SetPermissionsForKey(int key,
 // static
 DISABLE_CFI_ICALL
 MemoryProtectionKey::Permission MemoryProtectionKey::GetKeyPermission(int key) {
-  DCHECK(pkey_initialized);
+  DCHECK(pkey_api_initialized);
   DCHECK_NE(kNoMemoryProtectionKey, key);
 
   // If a valid key was allocated, {pkey_get()} must also be available.

--- a/src/base/platform/memory-protection-key.h
+++ b/src/base/platform/memory-protection-key.h
@@ -5,7 +5,7 @@
 #ifndef V8_BASE_PLATFORM_MEMORY_PROTECTION_KEY_H_
 #define V8_BASE_PLATFORM_MEMORY_PROTECTION_KEY_H_
 
-#if defined(V8_OS_LINUX) && defined(V8_HOST_ARCH_X64)
+#if V8_HAS_PKU_JIT_WRITE_PROTECT
 #include <sys/mman.h>  // For static_assert of permission values.
 #undef MAP_TYPE  // Conflicts with MAP_TYPE in Torque-generated instance-types.h
 #endif

--- a/src/base/platform/platform-posix.cc
+++ b/src/base/platform/platform-posix.cc
@@ -354,6 +354,10 @@ void* OS::GetRandomMmapAddr() {
   // TODO(RISCV): We need more information from the kernel to correctly mask
   // this address for RISC-V. https://github.com/v8-riscv/v8/issues/375
   raw_addr &= uint64_t{0xFFFFFF0000};
+#elif V8_TARGET_ARCH_RISCV32
+  // TODO(RISCV): We need more information from the kernel to correctly mask
+  // this address for RISC-V. https://github.com/v8-riscv/v8/issues/375
+  raw_addr &= 0x3FFFF000;
 #elif V8_TARGET_ARCH_LOONG64
   // 42 bits of virtual addressing. Truncate to 40 bits to allow kernel chance
   // to fulfill request.
@@ -684,6 +688,8 @@ void OS::DebugBreak() {
   // Software breakpoint instruction is 0x0001
   asm volatile(".word 0x0001");
 #elif V8_HOST_ARCH_RISCV64
+  asm("ebreak");
+#elif V8_HOST_ARCH_RISCV32
   asm("ebreak");
 #else
 #error Unsupported host architecture.

--- a/src/base/small-vector.h
+++ b/src/base/small-vector.h
@@ -100,6 +100,12 @@ class SmallVector {
   T* end() { return end_; }
   const T* end() const { return end_; }
 
+  auto rbegin() { return std::make_reverse_iterator(end_); }
+  auto rbegin() const { return std::make_reverse_iterator(end_); }
+
+  auto rend() { return std::make_reverse_iterator(begin_); }
+  auto rend() const { return std::make_reverse_iterator(begin_); }
+
   size_t size() const { return end_ - begin_; }
   bool empty() const { return end_ == begin_; }
   size_t capacity() const { return end_of_storage_ - begin_; }

--- a/src/base/string-format.h
+++ b/src/base/string-format.h
@@ -171,6 +171,11 @@ class FormattedString {
   std::tuple<Part<Ts>...> parts_;
 };
 
+// Add an explicit deduction guide for empty template parameters (fixes
+// clang's -Wctad-maybe-unsupported warning). Non-empty formatted strings
+// explicitly declare template parameters anyway.
+FormattedString()->FormattedString<>;
+
 }  // namespace v8::base
 
 #endif  // V8_BASE_STRING_FORMAT_H_

--- a/src/heap/base/asm/riscv/push_registers_asm.cc
+++ b/src/heap/base/asm/riscv/push_registers_asm.cc
@@ -10,6 +10,7 @@
 //
 // Calling convention source:
 // https://riscv.org/wp-content/uploads/2015/01/riscv-calling.pdf Table 18.2
+#ifdef V8_TARGET_ARCH_RISCV64
 asm(".global PushAllRegistersAndIterateStack             \n"
     ".type PushAllRegistersAndIterateStack, %function    \n"
     ".hidden PushAllRegistersAndIterateStack             \n"
@@ -49,3 +50,44 @@ asm(".global PushAllRegistersAndIterateStack             \n"
     "  ld s0, 0(sp)                                      \n"
     "  addi sp, sp, 112                                  \n"
     "  jr ra                                             \n");
+#elif V8_TARGET_ARCH_RISCV32
+asm(".global PushAllRegistersAndIterateStack             \n"
+    ".type PushAllRegistersAndIterateStack, %function    \n"
+    ".hidden PushAllRegistersAndIterateStack             \n"
+    "PushAllRegistersAndIterateStack:                    \n"
+    // Push all callee-saved registers and save return address.
+    "  addi sp, sp, -56                                  \n"
+    // Save return address.
+    "  sw ra, 52(sp)                                     \n"
+    // sp is callee-saved.
+    "  sw sp, 48(sp)                                     \n"
+    // s0-s11 are callee-saved.
+    "  sw s11, 44(sp)                                    \n"
+    "  sw s10, 40(sp)                                    \n"
+    "  sw s9, 36(sp)                                     \n"
+    "  sw s8, 32(sp)                                     \n"
+    "  sw s7, 28(sp)                                     \n"
+    "  sw s6, 24(sp)                                     \n"
+    "  sw s5, 20(sp)                                     \n"
+    "  sw s4, 16(sp)                                     \n"
+    "  sw s3, 12(sp)                                     \n"
+    "  sw s2, 8(sp)                                      \n"
+    "  sw s1,  4(sp)                                     \n"
+    "  sw s0,  0(sp)                                     \n"
+    // Maintain frame pointer(fp is s0).
+    "  mv s0, sp                                         \n"
+    // Pass 1st parameter (a0) unchanged (Stack*).
+    // Pass 2nd parameter (a1) unchanged (StackVisitor*).
+    // Save 3rd parameter (a2; IterateStackCallback) to a3.
+    "  mv a3, a2                                         \n"
+    // Pass 3rd parameter as sp (stack pointer).
+    "  mv a2, sp                                         \n"
+    // Call the callback.
+    "  jalr a3                                           \n"
+    // Load return address.
+    "  lw ra, 52(sp)                                     \n"
+    // Restore frame pointer.
+    "  lw s0, 0(sp)                                      \n"
+    "  addi sp, sp, 56                                   \n"
+    "  jr ra                                             \n");
+#endif

--- a/src/heap/cppgc/caged-heap.cc
+++ b/src/heap/cppgc/caged-heap.cc
@@ -24,7 +24,7 @@
 #include "src/heap/cppgc/globals.h"
 #include "src/heap/cppgc/heap-base.h"
 #include "src/heap/cppgc/heap-page.h"
-#include "src/heap/cppgc/member.h"
+#include "src/heap/cppgc/member-storage.h"
 
 namespace cppgc {
 namespace internal {

--- a/src/heap/cppgc/concurrent-marker.cc
+++ b/src/heap/cppgc/concurrent-marker.cc
@@ -10,7 +10,6 @@
 #include "src/heap/cppgc/liveness-broker.h"
 #include "src/heap/cppgc/marking-state.h"
 #include "src/heap/cppgc/marking-visitor.h"
-#include "src/heap/cppgc/member.h"
 #include "src/heap/cppgc/stats-collector.h"
 
 namespace cppgc {

--- a/src/heap/cppgc/heap-base.cc
+++ b/src/heap/cppgc/heap-base.cc
@@ -252,6 +252,7 @@ void HeapBase::Terminate() {
     in_atomic_pause_ = true;
     stats_collector()->NotifyMarkingStarted(
         GarbageCollector::Config::CollectionType::kMajor,
+        GarbageCollector::Config::MarkingType::kAtomic,
         GarbageCollector::Config::IsForcedGC::kForced);
     object_allocator().ResetLinearAllocationBuffers();
     stats_collector()->NotifyMarkingCompleted(0);

--- a/src/heap/cppgc/marker.cc
+++ b/src/heap/cppgc/marker.cc
@@ -218,8 +218,8 @@ void MarkerBase::StartMarking() {
           ? StatsCollector::kAtomicMark
           : StatsCollector::kIncrementalMark);
 
-  heap().stats_collector()->NotifyMarkingStarted(config_.collection_type,
-                                                 config_.is_forced_gc);
+  heap().stats_collector()->NotifyMarkingStarted(
+      config_.collection_type, config_.marking_type, config_.is_forced_gc);
 
   is_marking_ = true;
   if (EnterIncrementalMarkingIfNeeded(config_, heap())) {
@@ -372,11 +372,12 @@ void MarkerBase::ProcessWeakness() {
             broker));
   }
 
-  heap().GetWeakPersistentRegion().Trace(&visitor());
+  RootMarkingVisitor root_marking_visitor(mutator_marking_state_);
+  heap().GetWeakPersistentRegion().Iterate(root_marking_visitor);
   // Processing cross-thread handles requires taking the process lock.
   g_process_mutex.Get().AssertHeld();
   CHECK(visited_cross_thread_persistents_in_atomic_pause_);
-  heap().GetWeakCrossThreadPersistentRegion().Trace(&visitor());
+  heap().GetWeakCrossThreadPersistentRegion().Iterate(root_marking_visitor);
 
   // Call weak callbacks on objects that may now be pointing to dead objects.
 #if defined(CPPGC_YOUNG_GENERATION)
@@ -436,7 +437,8 @@ void MarkerBase::VisitRoots(MarkingConfig::StackState stack_state) {
     {
       StatsCollector::DisabledScope inner_stats_scope(
           heap().stats_collector(), StatsCollector::kMarkVisitPersistents);
-      heap().GetStrongPersistentRegion().Trace(&visitor());
+      RootMarkingVisitor root_marking_visitor(mutator_marking_state_);
+      heap().GetStrongPersistentRegion().Iterate(root_marking_visitor);
     }
   }
 
@@ -467,7 +469,8 @@ bool MarkerBase::VisitCrossThreadPersistentsIfNeeded() {
   // converted into a CrossThreadPersistent which requires that the handle
   // is either cleared or the object is retained.
   g_process_mutex.Pointer()->Lock();
-  heap().GetStrongCrossThreadPersistentRegion().Trace(&visitor());
+  RootMarkingVisitor root_marking_visitor(mutator_marking_state_);
+  heap().GetStrongCrossThreadPersistentRegion().Iterate(root_marking_visitor);
   visited_cross_thread_persistents_in_atomic_pause_ = true;
   return (heap().GetStrongCrossThreadPersistentRegion().NodesInUse() > 0);
 }

--- a/src/heap/cppgc/marking-visitor.cc
+++ b/src/heap/cppgc/marking-visitor.cc
@@ -77,18 +77,20 @@ MutatorMarkingVisitor::MutatorMarkingVisitor(HeapBase& heap,
                                              MutatorMarkingState& marking_state)
     : MarkingVisitorBase(heap, marking_state) {}
 
-void MutatorMarkingVisitor::VisitRoot(const void* object, TraceDescriptor desc,
-                                      const SourceLocation&) {
-  Visit(object, desc);
+RootMarkingVisitor::RootMarkingVisitor(MutatorMarkingState& marking_state)
+    : mutator_marking_state_(marking_state) {}
+
+void RootMarkingVisitor::VisitRoot(const void* object, TraceDescriptor desc,
+                                   const SourceLocation&) {
+  mutator_marking_state_.MarkAndPush(object, desc);
 }
 
-void MutatorMarkingVisitor::VisitWeakRoot(const void* object,
-                                          TraceDescriptor desc,
-                                          WeakCallback weak_callback,
-                                          const void* weak_root,
-                                          const SourceLocation&) {
-  static_cast<MutatorMarkingState&>(marking_state_)
-      .InvokeWeakRootsCallbackIfNeeded(object, desc, weak_callback, weak_root);
+void RootMarkingVisitor::VisitWeakRoot(const void* object, TraceDescriptor desc,
+                                       WeakCallback weak_callback,
+                                       const void* weak_root,
+                                       const SourceLocation&) {
+  mutator_marking_state_.InvokeWeakRootsCallbackIfNeeded(
+      object, desc, weak_callback, weak_root);
 }
 
 ConcurrentMarkingVisitor::ConcurrentMarkingVisitor(

--- a/src/heap/cppgc/marking-visitor.h
+++ b/src/heap/cppgc/marking-visitor.h
@@ -42,11 +42,6 @@ class V8_EXPORT_PRIVATE MutatorMarkingVisitor : public MarkingVisitorBase {
  public:
   MutatorMarkingVisitor(HeapBase&, MutatorMarkingState&);
   ~MutatorMarkingVisitor() override = default;
-
- protected:
-  void VisitRoot(const void*, TraceDescriptor, const SourceLocation&) final;
-  void VisitWeakRoot(const void*, TraceDescriptor, WeakCallback, const void*,
-                     const SourceLocation&) final;
 };
 
 class V8_EXPORT_PRIVATE ConcurrentMarkingVisitor final
@@ -56,16 +51,21 @@ class V8_EXPORT_PRIVATE ConcurrentMarkingVisitor final
   ~ConcurrentMarkingVisitor() override = default;
 
  protected:
-  void VisitRoot(const void*, TraceDescriptor, const SourceLocation&) final {
-    UNREACHABLE();
-  }
-  void VisitWeakRoot(const void*, TraceDescriptor, WeakCallback, const void*,
-                     const SourceLocation&) final {
-    UNREACHABLE();
-  }
-
   bool DeferTraceToMutatorThreadIfConcurrent(const void*, TraceCallback,
                                              size_t) final;
+};
+
+class V8_EXPORT_PRIVATE RootMarkingVisitor : public RootVisitorBase {
+ public:
+  explicit RootMarkingVisitor(MutatorMarkingState&);
+  ~RootMarkingVisitor() override = default;
+
+ protected:
+  void VisitRoot(const void*, TraceDescriptor, const SourceLocation&) final;
+  void VisitWeakRoot(const void*, TraceDescriptor, WeakCallback, const void*,
+                     const SourceLocation&) final;
+
+  MutatorMarkingState& mutator_marking_state_;
 };
 
 class ConservativeMarkingVisitor : public ConservativeTracingVisitor,

--- a/src/heap/cppgc/member-storage.cc
+++ b/src/heap/cppgc/member-storage.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "include/cppgc/member.h"
+#include "include/cppgc/internal/member-storage.h"
 
 namespace cppgc {
 namespace internal {

--- a/src/heap/cppgc/member-storage.h
+++ b/src/heap/cppgc/member-storage.h
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef V8_HEAP_CPPGC_MEMBER_H_
-#define V8_HEAP_CPPGC_MEMBER_H_
+#ifndef V8_HEAP_CPPGC_MEMBER_STORAGE_H_
+#define V8_HEAP_CPPGC_MEMBER_STORAGE_H_
 
-#include "include/cppgc/member.h"
+#include "include/cppgc/internal/member-storage.h"
 
 namespace cppgc {
 namespace internal {
@@ -30,4 +30,4 @@ class CageBaseGlobalUpdater final {
 }  // namespace internal
 }  // namespace cppgc
 
-#endif  // V8_HEAP_CPPGC_MEMBER_H_
+#endif  // V8_HEAP_CPPGC_MEMBER_STORAGE_H_

--- a/src/heap/cppgc/stats-collector.cc
+++ b/src/heap/cppgc/stats-collector.cc
@@ -108,10 +108,12 @@ StatsCollector::Event::Event() {
 }
 
 void StatsCollector::NotifyMarkingStarted(CollectionType collection_type,
+                                          MarkingType marking_type,
                                           IsForcedGC is_forced_gc) {
   DCHECK_EQ(GarbageCollectionState::kNotRunning, gc_state_);
   current_.collection_type = collection_type;
   current_.is_forced_gc = is_forced_gc;
+  current_.marking_type = marking_type;
   gc_state_ = GarbageCollectionState::kMarking;
 }
 
@@ -169,7 +171,9 @@ int64_t SumPhases(const MetricRecorder::GCCycle::Phases& phases) {
 }
 
 MetricRecorder::GCCycle GetCycleEventForMetricRecorder(
-    StatsCollector::CollectionType type, int64_t atomic_mark_us,
+    StatsCollector::CollectionType type,
+    StatsCollector::MarkingType marking_type,
+    StatsCollector::SweepingType sweeping_type, int64_t atomic_mark_us,
     int64_t atomic_weak_us, int64_t atomic_compact_us, int64_t atomic_sweep_us,
     int64_t incremental_mark_us, int64_t incremental_sweep_us,
     int64_t concurrent_mark_us, int64_t concurrent_sweep_us,
@@ -181,8 +185,13 @@ MetricRecorder::GCCycle GetCycleEventForMetricRecorder(
                    ? MetricRecorder::GCCycle::Type::kMajor
                    : MetricRecorder::GCCycle::Type::kMinor;
   // MainThread.Incremental:
-  event.main_thread_incremental.mark_duration_us = incremental_mark_us;
-  event.main_thread_incremental.sweep_duration_us = incremental_sweep_us;
+  event.main_thread_incremental.mark_duration_us =
+      marking_type != StatsCollector::MarkingType::kAtomic ? incremental_mark_us
+                                                           : -1;
+  event.main_thread_incremental.sweep_duration_us =
+      sweeping_type != StatsCollector::SweepingType::kAtomic
+          ? incremental_sweep_us
+          : -1;
   // MainThread.Atomic:
   event.main_thread_atomic.mark_duration_us = atomic_mark_us;
   event.main_thread_atomic.weak_duration_us = atomic_weak_us;
@@ -190,15 +199,13 @@ MetricRecorder::GCCycle GetCycleEventForMetricRecorder(
   event.main_thread_atomic.sweep_duration_us = atomic_sweep_us;
   // MainThread:
   event.main_thread.mark_duration_us =
-      event.main_thread_atomic.mark_duration_us +
-      event.main_thread_incremental.mark_duration_us;
+      event.main_thread_atomic.mark_duration_us + incremental_mark_us;
   event.main_thread.weak_duration_us =
       event.main_thread_atomic.weak_duration_us;
   event.main_thread.compact_duration_us =
       event.main_thread_atomic.compact_duration_us;
   event.main_thread.sweep_duration_us =
-      event.main_thread_atomic.sweep_duration_us +
-      event.main_thread_incremental.sweep_duration_us;
+      event.main_thread_atomic.sweep_duration_us + incremental_sweep_us;
   // Total:
   event.total.mark_duration_us =
       event.main_thread.mark_duration_us + concurrent_mark_us;
@@ -240,14 +247,21 @@ MetricRecorder::GCCycle GetCycleEventForMetricRecorder(
 
 }  // namespace
 
-void StatsCollector::NotifySweepingCompleted() {
+void StatsCollector::NotifySweepingCompleted(SweepingType sweeping_type) {
   DCHECK_EQ(GarbageCollectionState::kSweeping, gc_state_);
   gc_state_ = GarbageCollectionState::kNotRunning;
+  current_.sweeping_type = sweeping_type;
   previous_ = std::move(current_);
   current_ = Event();
+  DCHECK_IMPLIES(previous_.marking_type == StatsCollector::MarkingType::kAtomic,
+                 previous_.scope_data[kIncrementalMark].IsZero());
+  DCHECK_IMPLIES(
+      previous_.sweeping_type == StatsCollector::SweepingType::kAtomic,
+      previous_.scope_data[kIncrementalSweep].IsZero());
   if (metric_recorder_) {
     MetricRecorder::GCCycle event = GetCycleEventForMetricRecorder(
-        previous_.collection_type,
+        previous_.collection_type, previous_.marking_type,
+        previous_.sweeping_type,
         previous_.scope_data[kAtomicMark].InMicroseconds(),
         previous_.scope_data[kAtomicWeak].InMicroseconds(),
         previous_.scope_data[kAtomicCompact].InMicroseconds(),

--- a/src/heap/cppgc/stats-collector.h
+++ b/src/heap/cppgc/stats-collector.h
@@ -71,6 +71,8 @@ class V8_EXPORT_PRIVATE StatsCollector final {
 
  public:
   using CollectionType = GarbageCollector::Config::CollectionType;
+  using MarkingType = GarbageCollector::Config::MarkingType;
+  using SweepingType = GarbageCollector::Config::SweepingType;
 
 #if defined(CPPGC_DECLARE_ENUM)
   static_assert(false, "CPPGC_DECLARE_ENUM macro is already defined");
@@ -107,6 +109,8 @@ class V8_EXPORT_PRIVATE StatsCollector final {
 
     size_t epoch = -1;
     CollectionType collection_type = CollectionType::kMajor;
+    MarkingType marking_type = MarkingType::kAtomic;
+    SweepingType sweeping_type = SweepingType::kAtomic;
     IsForcedGC is_forced_gc = IsForcedGC::kNotForced;
     // Marked bytes collected during marking.
     size_t marked_bytes = 0;
@@ -270,13 +274,13 @@ class V8_EXPORT_PRIVATE StatsCollector final {
   void NotifySafePointForTesting();
 
   // Indicates a new garbage collection cycle.
-  void NotifyMarkingStarted(CollectionType, IsForcedGC);
+  void NotifyMarkingStarted(CollectionType, MarkingType, IsForcedGC);
   // Indicates that marking of the current garbage collection cycle is
   // completed.
   void NotifyMarkingCompleted(size_t marked_bytes);
   // Indicates the end of a garbage collection cycle. This means that sweeping
   // is finished at this point.
-  void NotifySweepingCompleted();
+  void NotifySweepingCompleted(SweepingType);
 
   size_t allocated_memory_size() const;
   // Size of live objects in bytes  on the heap. Based on the most recent marked

--- a/src/heap/cppgc/sweeper.cc
+++ b/src/heap/cppgc/sweeper.cc
@@ -902,7 +902,7 @@ class Sweeper::SweeperImpl final {
     DCHECK(!is_in_progress_);
     DCHECK(notify_done_pending_);
     notify_done_pending_ = false;
-    stats_collector_->NotifySweepingCompleted();
+    stats_collector_->NotifySweepingCompleted(config_.sweeping_type);
   }
 
   void NotifyDoneIfNeeded() {

--- a/src/heap/cppgc/visitor.h
+++ b/src/heap/cppgc/visitor.h
@@ -15,7 +15,7 @@ class HeapBase;
 class HeapObjectHeader;
 class PageBackend;
 
-class VisitorFactory {
+class VisitorFactory final {
  public:
   static constexpr Visitor::Key CreateKey() { return {}; }
 };
@@ -24,16 +24,25 @@ class VisitorFactory {
 // use its internals.
 class VisitorBase : public cppgc::Visitor {
  public:
+  template <typename T>
+  static void TraceRawForTesting(cppgc::Visitor* visitor, const T* t) {
+    visitor->TraceImpl(t);
+  }
+
   VisitorBase() : cppgc::Visitor(VisitorFactory::CreateKey()) {}
   ~VisitorBase() override = default;
 
   VisitorBase(const VisitorBase&) = delete;
   VisitorBase& operator=(const VisitorBase&) = delete;
+};
 
-  template <typename Persistent>
-  void TraceRootForTesting(const Persistent& p, const SourceLocation& loc) {
-    TraceRoot(p, loc);
-  }
+class RootVisitorBase : public RootVisitor {
+ public:
+  RootVisitorBase() : RootVisitor(VisitorFactory::CreateKey()) {}
+  ~RootVisitorBase() override = default;
+
+  RootVisitorBase(const RootVisitorBase&) = delete;
+  RootVisitorBase& operator=(const RootVisitorBase&) = delete;
 };
 
 // Regular visitor that additionally allows for conservative tracing.

--- a/src/heap/cppgc/write-barrier.cc
+++ b/src/heap/cppgc/write-barrier.cc
@@ -215,7 +215,7 @@ YoungGenerationEnabler& YoungGenerationEnabler::Instance() {
 
 void YoungGenerationEnabler::Enable() {
   auto& instance = Instance();
-  v8::base::LockGuard _(&instance.mutex_);
+  v8::base::MutexGuard _(&instance.mutex_);
   if (++instance.is_enabled_ == 1) {
     // Enter the flag so that the check in the write barrier will always trigger
     // when young generation is enabled.
@@ -225,7 +225,7 @@ void YoungGenerationEnabler::Enable() {
 
 void YoungGenerationEnabler::Disable() {
   auto& instance = Instance();
-  v8::base::LockGuard _(&instance.mutex_);
+  v8::base::MutexGuard _(&instance.mutex_);
   DCHECK_LT(0, instance.is_enabled_);
   if (--instance.is_enabled_ == 0) {
     WriteBarrier::FlagUpdater::Exit();
@@ -234,7 +234,7 @@ void YoungGenerationEnabler::Disable() {
 
 bool YoungGenerationEnabler::IsEnabled() {
   auto& instance = Instance();
-  v8::base::LockGuard _(&instance.mutex_);
+  v8::base::MutexGuard _(&instance.mutex_);
   return instance.is_enabled_;
 }
 

--- a/src/libplatform/default-platform.cc
+++ b/src/libplatform/default-platform.cc
@@ -273,12 +273,16 @@ v8::PageAllocator* DefaultPlatform::GetPageAllocator() {
 }
 
 void DefaultPlatform::NotifyIsolateShutdown(Isolate* isolate) {
-  base::MutexGuard guard(&lock_);
-  auto it = foreground_task_runner_map_.find(isolate);
-  if (it != foreground_task_runner_map_.end()) {
-    it->second->Terminate();
-    foreground_task_runner_map_.erase(it);
+  std::shared_ptr<DefaultForegroundTaskRunner> taskrunner;
+  {
+    base::MutexGuard guard(&lock_);
+    auto it = foreground_task_runner_map_.find(isolate);
+    if (it != foreground_task_runner_map_.end()) {
+      taskrunner = it->second;
+      foreground_task_runner_map_.erase(it);
+    }
   }
+  taskrunner->Terminate();
 }
 
 }  // namespace platform

--- a/src/libplatform/etw/etw-provider-win.h
+++ b/src/libplatform/etw/etw-provider-win.h
@@ -1,0 +1,37 @@
+// Copyright 2022 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_LIBPLATFORM_ETW_ETW_PROVIDER_WIN_H_
+#define V8_LIBPLATFORM_ETW_ETW_PROVIDER_WIN_H_
+
+// This file defines all the ETW Provider functions.
+#include <windows.h>
+#ifndef VOID
+#define VOID void
+#endif
+#include <TraceLoggingProvider.h>
+#include <evntprov.h>
+#include <evntrace.h>  // defines TRACE_LEVEL_* and EVENT_TRACE_TYPE_*
+
+#include <cstdint>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
+#endif
+
+#ifndef V8_ETW_GUID
+#define V8_ETW_GUID \
+  0x57277741, 0x3638, 0x4A4B, 0xBD, 0xBA, 0x0A, 0xC6, 0xE4, 0x5D, 0xA5, 0x6C
+#endif  // V8_ETW_GUID
+
+#define V8_DECLARE_TRACELOGGING_PROVIDER(v8Provider) \
+  TRACELOGGING_DECLARE_PROVIDER(v8Provider);
+
+#define V8_DEFINE_TRACELOGGING_PROVIDER(v8Provider) \
+  TRACELOGGING_DEFINE_PROVIDER(v8Provider, "V8.js", (V8_ETW_GUID));
+
+#endif  // V8_LIBPLATFORM_ETW_ETW_PROVIDER_WIN_H_

--- a/src/libplatform/tracing/recorder-win.cc
+++ b/src/libplatform/tracing/recorder-win.cc
@@ -4,22 +4,15 @@
 #ifndef V8_LIBPLATFORM_TRACING_RECORDER_WIN_H_
 #define V8_LIBPLATFORM_TRACING_RECORDER_WIN_H_
 
-#include <Windows.h>
-#include <TraceLoggingProvider.h>
-
+#include "src/libplatform/etw/etw-provider-win.h"
 #include "src/libplatform/tracing/recorder.h"
-
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wc++98-compat-extra-semi"
-#endif
 
 namespace v8 {
 namespace platform {
 namespace tracing {
 
-TRACELOGGING_DECLARE_PROVIDER(g_v8LibProvider);
-
-TRACELOGGING_DEFINE_PROVIDER(g_v8LibProvider, "V8.js", (V8_ETW_GUID));
+V8_DECLARE_TRACELOGGING_PROVIDER(g_v8LibProvider);
+V8_DEFINE_TRACELOGGING_PROVIDER(g_v8LibProvider);
 
 Recorder::Recorder() { TraceLoggingRegister(g_v8LibProvider); }
 

--- a/src/libplatform/tracing/recorder.h
+++ b/src/libplatform/tracing/recorder.h
@@ -9,22 +9,15 @@
 
 #include "include/libplatform/v8-tracing.h"
 
-#if !defined(V8_ENABLE_SYSTEM_INSTRUMENTATION)
-#error "only include this file if V8_ENABLE_SYSTEM_INSTRUMENTATION"
-#endif
-
 #if V8_OS_DARWIN
 #include <os/signpost.h>
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
 #endif
 
-#if V8_OS_WIN
-#ifndef V8_ETW_GUID
-#define V8_ETW_GUID \
-  0x57277741, 0x3638, 0x4A4B, 0xBD, 0xBA, 0x0A, 0xC6, 0xE4, 0x5D, 0xA5, 0x6C
-#endif
-#endif
+#if !defined(V8_ENABLE_SYSTEM_INSTRUMENTATION)
+#error "only include this file if V8_ENABLE_SYSTEM_INSTRUMENTATION"
+#endif  // V8_ENABLE_SYSTEM_INSTRUMENTATION
 
 namespace v8 {
 namespace platform {

--- a/test/unittests/heap/cppgc/compactor-unittest.cc
+++ b/test/unittests/heap/cppgc/compactor-unittest.cc
@@ -31,7 +31,8 @@ struct CompactableGCed : public GarbageCollected<CompactableGCed> {
  public:
   ~CompactableGCed() { ++g_destructor_callcount; }
   void Trace(Visitor* visitor) const {
-    visitor->Trace(const_cast<const CompactableGCed*>(other));
+    VisitorBase::TraceRawForTesting(visitor,
+                                    const_cast<const CompactableGCed*>(other));
     visitor->RegisterMovableReference(
         const_cast<const CompactableGCed**>(&other));
   }
@@ -53,7 +54,8 @@ struct CompactableHolder
 
   void Trace(Visitor* visitor) const {
     for (int i = 0; i < kNumObjects; ++i) {
-      visitor->Trace(const_cast<const CompactableGCed*>(objects[i]));
+      VisitorBase::TraceRawForTesting(
+          visitor, const_cast<const CompactableGCed*>(objects[i]));
       visitor->RegisterMovableReference(
           const_cast<const CompactableGCed**>(&objects[i]));
     }
@@ -124,10 +126,12 @@ TEST_F(CompactorTest, NothingToCompact) {
   StartCompaction();
   heap()->stats_collector()->NotifyMarkingStarted(
       GarbageCollector::Config::CollectionType::kMajor,
+      GarbageCollector::Config::MarkingType::kAtomic,
       GarbageCollector::Config::IsForcedGC::kNotForced);
   heap()->stats_collector()->NotifyMarkingCompleted(0);
   FinishCompaction();
-  heap()->stats_collector()->NotifySweepingCompleted();
+  heap()->stats_collector()->NotifySweepingCompleted(
+      GarbageCollector::Config::SweepingType::kAtomic);
 }
 
 TEST_F(CompactorTest, NonEmptySpaceAllLive) {

--- a/test/unittests/heap/cppgc/concurrent-sweeper-unittest.cc
+++ b/test/unittests/heap/cppgc/concurrent-sweeper-unittest.cc
@@ -74,6 +74,7 @@ class ConcurrentSweeperTest : public testing::TestWithHeap {
     // methods are called in the right order.
     heap->stats_collector()->NotifyMarkingStarted(
         GarbageCollector::Config::CollectionType::kMajor,
+        GarbageCollector::Config::MarkingType::kAtomic,
         GarbageCollector::Config::IsForcedGC::kNotForced);
     heap->stats_collector()->NotifyMarkingCompleted(0);
     Sweeper& sweeper = heap->sweeper();

--- a/test/unittests/heap/cppgc/ephemeron-pair-unittest.cc
+++ b/test/unittests/heap/cppgc/ephemeron-pair-unittest.cc
@@ -66,7 +66,8 @@ class EphemeronPairTest : public testing::TestWithHeap {
     marker_->FinishMarking(MarkingConfig::StackState::kNoHeapPointers);
     // Pretend do finish sweeping as StatsCollector verifies that Notify*
     // methods are called in the right order.
-    Heap::From(GetHeap())->stats_collector()->NotifySweepingCompleted();
+    Heap::From(GetHeap())->stats_collector()->NotifySweepingCompleted(
+        GarbageCollector::Config::SweepingType::kIncremental);
   }
 
   void InitializeMarker(HeapBase& heap, cppgc::Platform* platform) {

--- a/test/unittests/heap/cppgc/heap-growing-unittest.cc
+++ b/test/unittests/heap/cppgc/heap-growing-unittest.cc
@@ -25,9 +25,11 @@ class FakeGarbageCollector : public GarbageCollector {
   void CollectGarbage(GarbageCollector::Config config) override {
     stats_collector_->NotifyMarkingStarted(
         GarbageCollector::Config::CollectionType::kMajor,
+        GarbageCollector::Config::MarkingType::kAtomic,
         GarbageCollector::Config::IsForcedGC::kNotForced);
     stats_collector_->NotifyMarkingCompleted(live_bytes_);
-    stats_collector_->NotifySweepingCompleted();
+    stats_collector_->NotifySweepingCompleted(
+        GarbageCollector::Config::SweepingType::kAtomic);
     callcount_++;
   }
 

--- a/test/unittests/heap/cppgc/marker-unittest.cc
+++ b/test/unittests/heap/cppgc/marker-unittest.cc
@@ -35,7 +35,8 @@ class MarkerTest : public testing::TestWithHeap {
     marker_->FinishMarking(stack_state);
     // Pretend do finish sweeping as StatsCollector verifies that Notify*
     // methods are called in the right order.
-    heap->stats_collector()->NotifySweepingCompleted();
+    heap->stats_collector()->NotifySweepingCompleted(
+        GarbageCollector::Config::SweepingType::kAtomic);
   }
 
   void InitializeMarker(HeapBase& heap, cppgc::Platform* platform,
@@ -372,7 +373,7 @@ class ObjectWithEphemeronPair final
     // the main marking worklist empty. If recording the ephemeron pair doesn't
     // as well, we will get a crash when destroying the marker.
     visitor->Trace(ephemeron_pair_);
-    visitor->Trace(const_cast<const SimpleObject*>(ephemeron_pair_.key.Get()));
+    visitor->TraceStrongly(ephemeron_pair_.key);
   }
 
  private:
@@ -416,7 +417,8 @@ class IncrementalMarkingTest : public testing::TestWithHeap {
     // Pretend do finish sweeping as StatsCollector verifies that Notify*
     // methods are called in the right order.
     GetMarkerRef().reset();
-    Heap::From(GetHeap())->stats_collector()->NotifySweepingCompleted();
+    Heap::From(GetHeap())->stats_collector()->NotifySweepingCompleted(
+        GarbageCollector::Config::SweepingType::kIncremental);
   }
 
   void InitializeMarker(HeapBase& heap, cppgc::Platform* platform,

--- a/test/unittests/heap/cppgc/member-unittest.cc
+++ b/test/unittests/heap/cppgc/member-unittest.cc
@@ -9,6 +9,7 @@
 
 #include "include/cppgc/allocation.h"
 #include "include/cppgc/garbage-collected.h"
+#include "include/cppgc/internal/member-storage.h"
 #include "include/cppgc/persistent.h"
 #include "include/cppgc/sentinel-pointer.h"
 #include "include/cppgc/type-traits.h"
@@ -65,6 +66,9 @@ struct CustomWriteBarrierPolicy {
     ++InitializingWriteBarriersTriggered;
   }
   static void AssigningBarrier(const void* slot, const void* value) {
+    ++AssigningWriteBarriersTriggered;
+  }
+  static void AssigningBarrier(const void* slot, MemberStorage) {
     ++AssigningWriteBarriersTriggered;
   }
 };

--- a/test/unittests/heap/cppgc/metric-recorder-unittest.cc
+++ b/test/unittests/heap/cppgc/metric-recorder-unittest.cc
@@ -53,11 +53,13 @@ class MetricRecorderTest : public testing::TestWithHeap {
   void StartGC() {
     stats->NotifyMarkingStarted(
         GarbageCollector::Config::CollectionType::kMajor,
+        GarbageCollector::Config::MarkingType::kIncremental,
         GarbageCollector::Config::IsForcedGC::kNotForced);
   }
   void EndGC(size_t marked_bytes) {
     stats->NotifyMarkingCompleted(marked_bytes);
-    stats->NotifySweepingCompleted();
+    stats->NotifySweepingCompleted(
+        GarbageCollector::Config::SweepingType::kIncremental);
   }
 
   StatsCollector* stats;
@@ -99,7 +101,7 @@ TEST_F(MetricRecorderTest, IncrementalScopesReportedImmediately) {
   EndGC(0);
 }
 
-TEST_F(MetricRecorderTest, NonIncrementlaScopesNotReportedImmediately) {
+TEST_F(MetricRecorderTest, NonIncrementalScopesNotReportedImmediately) {
   MetricRecorderImpl::GCCycle_callcount = 0u;
   MetricRecorderImpl::MainThreadIncrementalMark_callcount = 0u;
   MetricRecorderImpl::MainThreadIncrementalSweep_callcount = 0u;
@@ -306,7 +308,8 @@ TEST_F(MetricRecorderTest, ObjectSizeMetricsWithAllocations) {
   stats->NotifyAllocation(150);
   stats->NotifyAllocatedMemory(1000);
   stats->NotifyFreedMemory(400);
-  stats->NotifySweepingCompleted();
+  stats->NotifySweepingCompleted(
+      GarbageCollector::Config::SweepingType::kAtomic);
   EXPECT_EQ(1300u, MetricRecorderImpl::GCCycle_event.objects.before_bytes);
   EXPECT_EQ(800, MetricRecorderImpl::GCCycle_event.objects.after_bytes);
   EXPECT_EQ(500u, MetricRecorderImpl::GCCycle_event.objects.freed_bytes);

--- a/test/unittests/heap/cppgc/stats-collector-scopes-unittest.cc
+++ b/test/unittests/heap/cppgc/stats-collector-scopes-unittest.cc
@@ -78,7 +78,8 @@ class V8_NODISCARD CppgcTracingScopesTest : public testing::TestWithHeap {
     DelegatingTracingControllerImpl::check_expectations = false;
     GetMarkerRef()->FinishMarking(Config::StackState::kNoHeapPointers);
     GetMarkerRef().reset();
-    Heap::From(GetHeap())->stats_collector()->NotifySweepingCompleted();
+    Heap::From(GetHeap())->stats_collector()->NotifySweepingCompleted(
+        GarbageCollector::Config::SweepingType::kAtomic);
   }
 
   void ResetDelegatingTracingController(const char* expected_name = nullptr) {
@@ -229,9 +230,11 @@ TEST_F(CppgcTracingScopesTest, InitalScopesAreZero) {
   StatsCollector* stats_collector = Heap::From(GetHeap())->stats_collector();
   stats_collector->NotifyMarkingStarted(
       GarbageCollector::Config::CollectionType::kMajor,
+      GarbageCollector::Config::MarkingType::kAtomic,
       GarbageCollector::Config::IsForcedGC::kNotForced);
   stats_collector->NotifyMarkingCompleted(0);
-  stats_collector->NotifySweepingCompleted();
+  stats_collector->NotifySweepingCompleted(
+      GarbageCollector::Config::SweepingType::kAtomic);
   const StatsCollector::Event& event =
       stats_collector->GetPreviousEventForTesting();
   for (int i = 0; i < StatsCollector::kNumHistogramScopeIds; ++i) {
@@ -248,6 +251,7 @@ TEST_F(CppgcTracingScopesTest, TestIndividualScopes) {
     StatsCollector* stats_collector = Heap::From(GetHeap())->stats_collector();
     stats_collector->NotifyMarkingStarted(
         GarbageCollector::Config::CollectionType::kMajor,
+        GarbageCollector::Config::MarkingType::kIncremental,
         GarbageCollector::Config::IsForcedGC::kNotForced);
     DelegatingTracingControllerImpl::check_expectations = false;
     {
@@ -260,7 +264,8 @@ TEST_F(CppgcTracingScopesTest, TestIndividualScopes) {
       }
     }
     stats_collector->NotifyMarkingCompleted(0);
-    stats_collector->NotifySweepingCompleted();
+    stats_collector->NotifySweepingCompleted(
+        GarbageCollector::Config::SweepingType::kIncremental);
     const StatsCollector::Event& event =
         stats_collector->GetPreviousEventForTesting();
     for (int i = 0; i < StatsCollector::kNumHistogramScopeIds; ++i) {
@@ -281,6 +286,7 @@ TEST_F(CppgcTracingScopesTest, TestIndividualConcurrentScopes) {
     StatsCollector* stats_collector = Heap::From(GetHeap())->stats_collector();
     stats_collector->NotifyMarkingStarted(
         GarbageCollector::Config::CollectionType::kMajor,
+        GarbageCollector::Config::MarkingType::kAtomic,
         GarbageCollector::Config::IsForcedGC::kNotForced);
     DelegatingTracingControllerImpl::check_expectations = false;
     {
@@ -293,7 +299,8 @@ TEST_F(CppgcTracingScopesTest, TestIndividualConcurrentScopes) {
       }
     }
     stats_collector->NotifyMarkingCompleted(0);
-    stats_collector->NotifySweepingCompleted();
+    stats_collector->NotifySweepingCompleted(
+        GarbageCollector::Config::SweepingType::kAtomic);
     const StatsCollector::Event& event =
         stats_collector->GetPreviousEventForTesting();
     for (int i = 0; i < StatsCollector::kNumHistogramScopeIds; ++i) {

--- a/test/unittests/heap/cppgc/stats-collector-unittest.cc
+++ b/test/unittests/heap/cppgc/stats-collector-unittest.cc
@@ -39,18 +39,22 @@ class StatsCollectorTest : public ::testing::Test {
 
 TEST_F(StatsCollectorTest, NoMarkedBytes) {
   stats.NotifyMarkingStarted(GarbageCollector::Config::CollectionType::kMajor,
+                             GarbageCollector::Config::MarkingType::kAtomic,
                              GarbageCollector::Config::IsForcedGC::kNotForced);
   stats.NotifyMarkingCompleted(kNoMarkedBytes);
-  stats.NotifySweepingCompleted();
+  stats.NotifySweepingCompleted(
+      GarbageCollector::Config::SweepingType::kAtomic);
   auto event = stats.GetPreviousEventForTesting();
   EXPECT_EQ(0u, event.marked_bytes);
 }
 
 TEST_F(StatsCollectorTest, EventPrevGCMarkedObjectSize) {
   stats.NotifyMarkingStarted(GarbageCollector::Config::CollectionType::kMajor,
+                             GarbageCollector::Config::MarkingType::kAtomic,
                              GarbageCollector::Config::IsForcedGC::kNotForced);
   stats.NotifyMarkingCompleted(1024);
-  stats.NotifySweepingCompleted();
+  stats.NotifySweepingCompleted(
+      GarbageCollector::Config::SweepingType::kAtomic);
   auto event = stats.GetPreviousEventForTesting();
   EXPECT_EQ(1024u, event.marked_bytes);
 }
@@ -71,45 +75,53 @@ TEST_F(StatsCollectorTest, AlllocationReportAboveAllocationThresholdBytes) {
 
 TEST_F(StatsCollectorTest, InitialAllocatedObjectSize) {
   stats.NotifyMarkingStarted(GarbageCollector::Config::CollectionType::kMajor,
+                             GarbageCollector::Config::MarkingType::kAtomic,
                              GarbageCollector::Config::IsForcedGC::kNotForced);
   EXPECT_EQ(0u, stats.allocated_object_size());
   stats.NotifyMarkingCompleted(kNoMarkedBytes);
   EXPECT_EQ(0u, stats.allocated_object_size());
-  stats.NotifySweepingCompleted();
+  stats.NotifySweepingCompleted(
+      GarbageCollector::Config::SweepingType::kAtomic);
   EXPECT_EQ(0u, stats.allocated_object_size());
 }
 
 TEST_F(StatsCollectorTest, AllocatedObjectSize) {
   stats.NotifyMarkingStarted(GarbageCollector::Config::CollectionType::kMajor,
+                             GarbageCollector::Config::MarkingType::kAtomic,
                              GarbageCollector::Config::IsForcedGC::kNotForced);
   FakeAllocate(kMinReportedSize);
   EXPECT_EQ(kMinReportedSize, stats.allocated_object_size());
   stats.NotifyMarkingCompleted(kMinReportedSize);
   EXPECT_EQ(kMinReportedSize, stats.allocated_object_size());
-  stats.NotifySweepingCompleted();
+  stats.NotifySweepingCompleted(
+      GarbageCollector::Config::SweepingType::kAtomic);
   EXPECT_EQ(kMinReportedSize, stats.allocated_object_size());
 }
 
 TEST_F(StatsCollectorTest, AllocatedObjectSizeNoMarkedBytes) {
   stats.NotifyMarkingStarted(GarbageCollector::Config::CollectionType::kMajor,
+                             GarbageCollector::Config::MarkingType::kAtomic,
                              GarbageCollector::Config::IsForcedGC::kNotForced);
   FakeAllocate(kMinReportedSize);
   EXPECT_EQ(kMinReportedSize, stats.allocated_object_size());
   stats.NotifyMarkingCompleted(kNoMarkedBytes);
   EXPECT_EQ(0u, stats.allocated_object_size());
-  stats.NotifySweepingCompleted();
+  stats.NotifySweepingCompleted(
+      GarbageCollector::Config::SweepingType::kAtomic);
   EXPECT_EQ(0u, stats.allocated_object_size());
 }
 
 TEST_F(StatsCollectorTest, AllocatedObjectSizeAllocateAfterMarking) {
   stats.NotifyMarkingStarted(GarbageCollector::Config::CollectionType::kMajor,
+                             GarbageCollector::Config::MarkingType::kAtomic,
                              GarbageCollector::Config::IsForcedGC::kNotForced);
   FakeAllocate(kMinReportedSize);
   EXPECT_EQ(kMinReportedSize, stats.allocated_object_size());
   stats.NotifyMarkingCompleted(kMinReportedSize);
   FakeAllocate(kMinReportedSize);
   EXPECT_EQ(2 * kMinReportedSize, stats.allocated_object_size());
-  stats.NotifySweepingCompleted();
+  stats.NotifySweepingCompleted(
+      GarbageCollector::Config::SweepingType::kAtomic);
   EXPECT_EQ(2 * kMinReportedSize, stats.allocated_object_size());
 }
 
@@ -142,9 +154,11 @@ namespace {
 
 void FakeGC(StatsCollector* stats, size_t marked_bytes) {
   stats->NotifyMarkingStarted(GarbageCollector::Config::CollectionType::kMajor,
+                              GarbageCollector::Config::MarkingType::kAtomic,
                               GarbageCollector::Config::IsForcedGC::kNotForced);
   stats->NotifyMarkingCompleted(marked_bytes);
-  stats->NotifySweepingCompleted();
+  stats->NotifySweepingCompleted(
+      GarbageCollector::Config::SweepingType::kAtomic);
 }
 
 }  // namespace

--- a/test/unittests/heap/cppgc/sweeper-unittest.cc
+++ b/test/unittests/heap/cppgc/sweeper-unittest.cc
@@ -49,6 +49,7 @@ class SweeperTest : public testing::TestWithHeap {
     // methods are called in the right order.
     heap->stats_collector()->NotifyMarkingStarted(
         GarbageCollector::Config::CollectionType::kMajor,
+        GarbageCollector::Config::MarkingType::kAtomic,
         GarbageCollector::Config::IsForcedGC::kNotForced);
     heap->stats_collector()->NotifyMarkingCompleted(0);
     const Sweeper::SweepingConfig sweeping_config{

--- a/test/unittests/heap/cppgc/weak-container-unittest.cc
+++ b/test/unittests/heap/cppgc/weak-container-unittest.cc
@@ -36,7 +36,8 @@ class WeakContainerTest : public testing::TestWithHeap {
     marked_bytes_ =
         Heap::From(GetHeap())->AsBase().stats_collector()->marked_bytes();
     GetMarkerRef().reset();
-    Heap::From(GetHeap())->stats_collector()->NotifySweepingCompleted();
+    Heap::From(GetHeap())->stats_collector()->NotifySweepingCompleted(
+        GarbageCollector::Config::SweepingType::kAtomic);
   }
 
   size_t GetMarkedBytes() const { return marked_bytes_; }


### PR DESCRIPTION
List of included changes:

  - d15d49b09dc7aef9edcc4cf6a0cb2b77a0db203f Make bitfields only as wide as necessary for enums by Nico Weber <thakis@chromium.org>
  - 0505419a1e7a704b99500067622e36e5afd49c8d cppgc: Split of roots visitation from regular Visitor by Michael Lippautz <mlippautz@chromium.org>
  - dff6d86419eb8268c567ed0b7cb9da72cdce52ac [include] Make Platform::CreateJob abstract by Clemens Backes <clemensb@chromium.org>
  - 491de34bcc84e33468c7b299027b1f6b59ec2d15 [riscv32] Add RISCV32 backend by Lu Yahan <yahan@iscas.ac.cn>
  - 2746000c3e340dcdfc381a45f01e30a4456097bf cppgc: Don't verify stack if PC is enabled. by Anton Bikineev <bikineev@chromium.org>
  - ccefc2e2732d9d77f6e4a20ccf97debf7cd647d9 Reland "[pku][wasm] Refactor PKU usage in Wasm" by wenqin.yang <wenqin.yang@intel.com>
  - eb89d2c92f1fca517b8d27ed8f718ac85dbdaaed Reland "cppgc: Consistently treat sentinel pointer as live" by Michael Lippautz <mlippautz@chromium.org>
  - 1078ab76665a268ca41d152f38f44a46f25281cc Remove workaround for C++14 by Clemens Backes <clemensb@chromium.org>
  - 6e72b810c5c0e943fc0651ed9b03fe978e1a971e [API] Allow copying of structs with deprecated fields by Clemens Backes <clemensb@chromium.org>
  - f7ad199e4a72bf59fc652af7f55806b75d2dc711 Reland "cppgc: Move forward Trace(T*) deprecation" by Michael Lippautz <mlippautz@chromium.org>
  - 2253d9c523a7eb52d08831df35e88d6907014409 Revert "[pku][wasm] Refactor PKU usage in Wasm" by Leszek Swirski <leszeks@chromium.org>
  - 4e935c7ffbeb91e46a6025866eba239d71f5a99d [pku][wasm] Refactor PKU usage in Wasm by wenqin.yang <wenqin.yang@intel.com>
  - 52bc4db68a53f78a7275e0af6bc3b5e5d3926551 Revert "cppgc: Move forward Trace(T*) deprecation" by Deepti Gandluri <gdeepti@chromium.org>
  - 0609bb8373d6176ba93d82549cefb5cae2548dff cppgc: Move forward Trace(T*) deprecation by Michael Lippautz <mlippautz@chromium.org>
  - 69fcc196f46be7332b979d7586ac95f3b29d9404 Revert "cppgc: Consistently treat sentinel pointer as live" by Leszek Swirski <leszeks@chromium.org>
  - 588fa294ef954bd98ce3092f70978106adf780d8 [API] Prepare deprecation of second OnCriticalMemoryPress... by Clemens Backes <clemensb@chromium.org>
  - 60e9b50374ac9bd8b88cf27cf237aa8aa205182c cppgc: Consistently treat sentinel pointer as live by Michael Lippautz <mlippautz@chromium.org>
  - 40a5328b7fadb76d0008b4cb6e2aa5e574996eda [d8] Avoid lock-order-inversion warning in the DefaultPla... by Andreas Haas <ahaas@chromium.org>
  - 18751c5b4669ec5c754786419790e24207953a75 [include] Make Platform::GetPageAllocator abstract by Clemens Backes <clemensb@chromium.org>
  - 0998bbe6fb6b41b746ae334f97f60d20d2fee573 Implement V8_ASSUME via __builtin_unreachable for GCC by Clemens Backes <clemensb@chromium.org>
  - 376813dfeb129907f0b892ee5c7350e8a554b3ea [fastcall] Implement support for Uint8Array arguments by Divy Srivastava <dj.srivastava23@gmail.com>
  - 4baf6a2fdebcb01ed34188106f6868aa937bbcb0 Separates ETW Stack Walking Events from Generic ETW Events by Suraj Sharma <surshar@microsoft.com>
  - d188467bf81839f69e7d28396de9a2a793fa2c62 cppgc: Introduce trace method for containers by Michael Lippautz <mlippautz@chromium.org>
  - 7b4c2ff5a3330dbc6799f63bd4bfd9327308a192 [build] Enable -Wctad-maybe-unsupported by Clemens Backes <clemensb@chromium.org>
  - 9b913366d4eeb32a498484c29710aeae2bdd970b [liftoff] Mark tagged safepoint slots in reversed order by Clemens Backes <clemensb@chromium.org>
  - eb4e0241d7fada6b59d158e6614bc907b898abd3 cppgc: Deprecate (soon) cppgc::Visitor::Trace(T*) by Michael Lippautz <mlippautz@chromium.org>
  - 509ee760d997093a0f8e5981c60649a5be420bce cppgc: Avoid decompression for Member write barriers by Michael Lippautz <mlippautz@chromium.org>
  - cdf548dacc90ed372b487effa1588e5002e63e79 [heap] Bug fix and zeros in metrics for incremental mark/... by Nikolaos Papaspyrou <nikolaos@chromium.org>

GitOrigin-RevId: d15d49b09dc7aef9edcc4cf6a0cb2b77a0db203f