### PR TITLE
Fix for  macOS 13.0

### DIFF
--- a/src/base/platform/platform-darwin.cc
+++ b/src/base/platform/platform-darwin.cc
@@ -52,8 +52,8 @@ std::vector<OS::SharedLibraryAddress> OS::GetSharedLibraryAddresses() {
     unsigned int size;
     char* code_ptr = getsectdatafromheader(header, SEG_TEXT, SECT_TEXT, &size);
 #else
-    uint64_t size;
-    char* code_ptr = getsectdatafromheader_64(
+    u_long size;
+    uint8_t* code_ptr = getsectiondata(
         reinterpret_cast<const mach_header_64*>(header), SEG_TEXT, SECT_TEXT,
         &size);
 #endif


### PR DESCRIPTION
I've faced this compilation error and would like to suggest a fix for it:
```
src/base/platform/platform-darwin.cc:56:22: error: 'getsectdatafromheader_64' is deprecated: first deprecated in macOS 13.0 [-Werror,-Wdeprecated-declarations]
    char* code_ptr = getsectdatafromheader_64(
                     ^~~~~~~~~~~~~~~~~~~~~~~~
                     use getsectiondata()
```